### PR TITLE
change mageia template to use python-devel

### DIFF
--- a/pyp2rpm/templates/mageia.spec
+++ b/pyp2rpm/templates/mageia.spec
@@ -19,11 +19,11 @@ Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.vers
 {%- if not data.has_extension %}
 BuildArch:      noarch
 {%- endif %}
-{{ dependencies(data.build_deps, False, data.base_python_version, data.base_python_version) }}
+{{ dependencies(data.build_deps, False, data.base_python_version, data.base_python_version) | replace("python2-devel", "python-devel") }}
 {%- for pv in data.python_versions %}
-{{ dependencies(data.build_deps, False, pv, data.base_python_version) }}
+{{ dependencies(data.build_deps, False, pv, data.base_python_version)  | replace("python2-devel", "python-devel") }}
 {%- endfor %}
-{{ dependencies(data.runtime_deps, True, data.base_python_version, data.base_python_version) }}
+{{ dependencies(data.runtime_deps, True, data.base_python_version, data.base_python_version)  | replace("python2-devel", "python-devel") }}
 
 %description
 {{ data.description|truncate(400)|wordwrap }}


### PR DESCRIPTION
Mageia still uses python-devel as the dependency name rather
than python2-devel.  This changes the mageia template to
modify the output of the macro.
