### PR TITLE
Updated python packaging guidelines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,9 @@ All of the options are (print this by running pyp2rpm -h::
                           associated and ignore this.
       -b BASE_PYTHON      Base Python version to package for (default: "2").
       -p PYTHON_VERSIONS  Additional Python versions to include in the specfile 
-                          (e.g -p3 for %{?with_python3}). Can be specified multiple times.
+                          (e.g -p3 for %{?with_python3}). Can be specified multiple times
+                          (default: "3"). Specify additional version or use -b
+                          explicitly to disable default. 
       --srpm              When used pyp2rpm will produce srpm instead of printing 
                           specfile into stdout.
       --proxy PROXY       Specify proxy in the form proxy.server:port.

--- a/pyp2rpm/archive.py
+++ b/pyp2rpm/archive.py
@@ -83,7 +83,7 @@ class Archive(object):
     def open(self):
         try:
             self.handle = self.extractor_cls.open(self.file)
-        except BaseException:  # TODO: log
+        except BaseException:
             self.handle = None
             logger.error('Failed to open archive: {0}.'.format(self.file), exc_info=True)
 
@@ -113,9 +113,6 @@ class Archive(object):
         elif self.is_zip:
             file_cls = ZipFile
         else:
-            pass
-            # TODO: log that file has unextractable archive suffix and we can't
-            # look inside the archive
             logger.info("Couldn't recognize archive suffix: {0}.".format(self.suffix))
 
         return file_cls
@@ -135,7 +132,8 @@ class Archive(object):
         """
         if self.handle:
             for member in self.handle.getmembers():
-                if (full_path and member.name == name) or (not full_path and os.path.basename(member.name) == name):
+                if (full_path and member.name == name)\
+                or (not full_path and os.path.basename(member.name) == name):
                     extracted = self.handle.extractfile(member)
                     return extracted.read().decode(locale.getpreferredencoding())
 
@@ -146,7 +144,8 @@ class Archive(object):
         Args:
             suffixes: list of suffixes or single suffix to look for
         Returns:
-            True if there is at least one file with at least one given suffix in the archive, False otherwise (or archive can't be opened)
+            True if there is at least one file with at least one given suffix in the archive,
+            False otherwise (or archive can't be opened)
         """
         if not isinstance(suffixes, list):
             suffixes = [suffixes]
@@ -186,7 +185,8 @@ class Archive(object):
             for member in self.handle.getmembers():
                 if isinstance(member, TarInfo) and member.isdir():
                     pass  # for TarInfo files, filter out directories
-                elif (full_path and compiled_re.search(member.name)) or (not full_path and compiled_re.search(os.path.basename(member.name))):
+                elif (full_path and compiled_re.search(member.name))\
+                or (not full_path and compiled_re.search(os.path.basename(member.name))):
                     found.append(member.name)
 
         return found
@@ -215,7 +215,8 @@ class Archive(object):
         return list(found)
 
     def find_list_argument(self, setup_argument):
-        """A simple method that gets setup() function from setup.py list argument like install_requires.
+        """A simple method that gets setup() function from setup.py list argument
+           like install_requires.
 
         Will not work in all cases and might need a smarter approach.
         On the other side, it's so stupid, that it's actually smart - it gets this:
@@ -281,7 +282,8 @@ class Archive(object):
                 return []
 
     def has_argument(self, argument):
-        """A simple method that finds out if setup() function from setup.py is called with given argument.
+        """A simple method that finds out if setup() function from setup.py 
+           is called with given argument.
         Args:
             argument: argument to look for
         Returns:
@@ -334,6 +336,3 @@ class Archive(object):
                     modules.append(re.sub('/.*', '', line))
 
         return {'modules': set(modules), 'scripts': set(scripts)}
-
-
-

--- a/pyp2rpm/bin.py
+++ b/pyp2rpm/bin.py
@@ -25,10 +25,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('-b',
               help='Base Python version to package for (default: "{0}").'.format(
                   settings.DEFAULT_PYTHON_VERSION),
-              default=settings.DEFAULT_PYTHON_VERSION,
+              default=None,
               metavar='BASE_PYTHON')
 @click.option('-p',
-              help='Additional Python versions to include in the specfile (e.g -p3 for %%{?with_python3}). Can be specified multiple times.',
+              help='Additional Python versions to include in the specfile (e.g -p3 for %%{0}). Can be specified multiple times (default: "{1}"). Specify additional version or use -b explicitly to disable default.'.format(
+                  '{?with_python3}', settings.DEFAULT_ADDITIONAL_VERSION),
               default=[],
               multiple=True,
               metavar='PYTHON_VERSIONS')
@@ -59,7 +60,15 @@ def main(package, v, d, r, proxy, srpm, p, b, o, t):
     PACKAGE             Provide PyPI name of the package or path to compressed source file."""
     register_file_log_handler('/tmp/pyp2rpm-{0}.log'.format(getpass.getuser()))
 
+    if not p and not b:
+        p = settings.DEFAULT_ADDITIONAL_VERSION
+    if not b:
+        b = settings.DEFAULT_PYTHON_VERSION
+    
     p = list(p)
+    if b in p:
+        p.remove(b)
+
     if srpm:
         register_console_log_handler()
 

--- a/pyp2rpm/bin.py
+++ b/pyp2rpm/bin.py
@@ -14,11 +14,13 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-t',
-              help='Template file (jinja2 format) to render (default: "{0}"). Search order is 1) filesystem, 2) default templates.'.format(
+              help='Template file (jinja2 format) to render (default: "{0}").' 
+              'Search order is 1) filesystem, 2) default templates.'.format(
                   settings.DEFAULT_TEMPLATE),
               metavar='TEMPLATE')
 @click.option('-o',
-              help='Default distro whose conversion rules to use (default: "{0}"). Default templates have their rules associated and ignore this.'.format(
+              help='Default distro whose conversion rules to use (default:"{0}").'
+              'Default templates have their rules associated and ignore this.'.format(
                   settings.DEFAULT_DISTRO),
               type=click.Choice(settings.KNOWN_DISTROS),
               default=settings.DEFAULT_DISTRO)
@@ -28,7 +30,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               default=None,
               metavar='BASE_PYTHON')
 @click.option('-p',
-              help='Additional Python versions to include in the specfile (e.g -p3 for %%{0}). Can be specified multiple times (default: "{1}"). Specify additional version or use -b explicitly to disable default.'.format(
+              help='Additional Python versions to include in the specfile (e.g -p3 for %%{0}).'
+              'Can be specified multiple times (default: "{1}"). Specify additional version'
+              'or use -b explicitly to disable default.'.format(
                   '{?with_python3}', settings.DEFAULT_ADDITIONAL_VERSION),
               default=[],
               multiple=True,
@@ -52,6 +56,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('-v', help='Version of the package to download (ignored for local files).',
               metavar='VERSION')
 @click.argument('package', nargs=1)
+
 def main(package, v, d, r, proxy, srpm, p, b, o, t):
     """Convert PyPI package to RPM specfile or SRPM.
 

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -77,8 +77,7 @@ class Convertor(object):
         data.python_versions = self.python_versions
         jinja_env = jinja2.Environment(loader=jinja2.ChoiceLoader([
             jinja2.FileSystemLoader(['/']),
-            jinja2.PackageLoader('pyp2rpm', 'templates'), ])
-        )
+            jinja2.PackageLoader('pyp2rpm', 'templates'), ]))
 
         for filter in filters.__all__:
             jinja_env.filters[filter.__name__] = filter
@@ -198,7 +197,7 @@ class Convertor(object):
 
 class ProxyTransport(xmlrpclib.Transport):
     """This class serves as Proxy Transport for XMLRPC server."""
-    
+
     def request(self, host, handler, request_body, verbose):
         self.verbose = verbose
         url = 'http://{0}{1}'.format(host, handler)

--- a/pyp2rpm/dependency_parser.py
+++ b/pyp2rpm/dependency_parser.py
@@ -53,9 +53,9 @@ def deps_from_pyp_format(requires, runtime=True):
     for req in requires:
         try:
             parsed.append(Requirement.parse(req))
-        except ValueError:  # TODO: log unparsable dependency
+        except ValueError:
             logger.warn('Unparsable dependency {0}.'.format(req), exc_info=True)
-            pass
+
     in_rpm_format = []
     for dep in parsed:
         in_rpm_format.extend(dependency_to_rpm(dep, runtime))

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -53,7 +53,7 @@ def package_to_path(package, module):
     if package == module:
         return "%{pypi_name}"
     else:
-        return package.replace('-','_')
+        return package.replace('-', '_')
 
 __all__ = [name_for_python_version,
            script_name_for_python_version,

--- a/pyp2rpm/logger.py
+++ b/pyp2rpm/logger.py
@@ -11,11 +11,11 @@ console_formatter = logging.Formatter(u'%(levelname)s  %(message)s')
 
 
 class LevelFilter(logging.Filter):
-        def __init__(self, level):
-            self.level = level
+    def __init__(self, level):
+        self.level = level
 
-        def filter(self, record):
-            return record.levelno == self.level
+    def filter(self, record):
+        return record.levelno == self.level
 
 
 def register_file_log_handler(log_file, level=logging.DEBUG, fmt=file_formatter):

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -299,6 +299,7 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
                            url)
         for data_field in settings.PYPI_USABLE_DATA:
             setattr(data, data_field, release_data.get(data_field, ''))
+        pypi_license = data.license
 
         with self.archive:
             data.set_from(self.data_from_archive)
@@ -310,7 +311,7 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
 
         # we usually get better license representation from trove classifiers
         data.license = utils.license_from_trove(
-            release_data.get('classifiers', '')) or data.license
+            release_data.get('classifiers', '')) or data.license or pypi_license
 
         return data
 

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -33,7 +33,8 @@ class LocalMetadataExtractor(object):
     def runtime_deps_from_setup_py(self):  # install_requires
         """ Returns list of runtime dependencies of the package specified in setup.py.
 
-        Dependencies are in RPM SPECFILE format - see dependency_to_rpm() for details, but names are already
+        Dependencies are in RPM SPECFILE format - see dependency_to_rpm() for details,
+        but names are already
         transformed according to current distro.
 
         Returns:
@@ -42,7 +43,7 @@ class LocalMetadataExtractor(object):
         install_requires = self.archive.find_list_argument('install_requires')
         if self.archive.has_argument('entry_points') and 'setuptools' not in install_requires:
             install_requires.append('setuptools') # entrypoints
-            
+
         return self.name_convert_deps_list(deps_from_pyp_format(install_requires, runtime=True))
 
     @property
@@ -56,8 +57,10 @@ class LocalMetadataExtractor(object):
         if 'setuptools' in build_requires:
             build_requires.remove('setuptools')
 
-        build = self.name_convert_deps_list(deps_from_pyp_format(build_requires, runtime=False))
-        test = self.name_convert_deps_list(deps_from_pyp_format(self.archive.find_list_argument('tests_require'), runtime=False))
+        build = self.name_convert_deps_list(
+            deps_from_pyp_format(build_requires, runtime=False))
+        test = self.name_convert_deps_list(
+            deps_from_pyp_format(self.archive.find_list_argument('tests_require'), runtime=False))
 
         return list(build + test)
 
@@ -65,8 +68,8 @@ class LocalMetadataExtractor(object):
     def runtime_deps_from_egg_info(self):
         """ Returns list of runtime dependencies of the package specified in EGG-INFO/requires.txt.
 
-        Dependencies are in RPM SPECFILE format - see dependency_to_rpm() for details, but names are already
-        transformed according to current distro.
+        Dependencies are in RPM SPECFILE format - see dependency_to_rpm() for details,
+        but names are already transformed according to current distro.
 
         Returns:
             list of runtime dependencies of the package
@@ -119,7 +122,7 @@ class LocalMetadataExtractor(object):
         for doc_file_re in settings.DOC_FILES_RE:
             doc_files.extend(
                 self.archive.get_files_re(doc_file_re, ignorecase=True))
-        return list(map(lambda x: "/".join(x.split("/")[1:]), doc_files))
+        return ['/'.join(x.split('/')[1:]) for x in doc_files]
 
     @property
     def sphinx_dir(self):
@@ -242,7 +245,7 @@ class LocalMetadataExtractor(object):
 
         # for example nose has attribute `packages` but instead of name listing the packages
         # is using function to find them, that makes data.packages an empty set
-        if(data.has_packages and not data.packages):
+        if data.has_packages and not data.packages:
             data.packages.add(data.name)
 
         return data
@@ -265,9 +268,10 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
             release_urls = self.client.release_urls(self.name, self.version)
             release_data = self.client.release_data(self.name, self.version)
         except:  # some kind of error with client => return TODO: log the failure
-            logger.debug('Client: {0} Name: {1} Version: {2}.'.format(self.client, self.name, self.version))
-            logger.warn(
-                'Some kind of error while communicating with client: {0}.'.format(self.client), exc_info=True)
+            logger.debug('Client: {0} Name: {1} Version: {2}.'.format(
+                self.client, self.name, self.version))
+            logger.warn('Some kind of error while communicating with client: {0}.'.format(
+                self.client), exc_info=True)
             return PackageData(self.local_file,
                                self.name,
                                self.name_convertor.rpm_name(self.name)
@@ -306,7 +310,7 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
 
         # for example nose has attribute `packages` but instead of name listing the
         # packages is using function to find them, that makes data.packages an empty set
-        if(data.has_packages and not data.packages):
+        if data.has_packages and not data.packages:
             data.packages.add(data.name)
 
         # we usually get better license representation from trove classifiers
@@ -321,7 +325,7 @@ class _WheelMetadataExtractor(PypiMetadataExtractor):
     @property
     def json_metadata(self):
         if not hasattr(self, '_json_metadata'):
-            self._json_metadata = self.archive.json_wheel_data
+            self._json_metadata = self.archive.json_wheel_metadata
         return self._json_metadata
 
     @property
@@ -348,7 +352,7 @@ class _WheelMetadataExtractor(PypiMetadataExtractor):
         for requires in self.json_metadata.get('test_requires', []):
             build_requires.extend(requires['requires'])
 
-        return self.name_convert_deps_list(deps_from_pydit_json(build_requires), runtime=False)
+        return self.name_convert_deps_list(deps_from_pydit_json(build_requires, runtime=False))
 
     @property
     def modules(self):

--- a/pyp2rpm/name_convertor.py
+++ b/pyp2rpm/name_convertor.py
@@ -31,7 +31,7 @@ class NameConvertor(object):
 
         if not version or version == settings.DEFAULT_PYTHON_VERSION:
             found = regexp.search(name)
-            if found and found.group(2)!='devel': # second check is to avoid renaming of python2-devel to python-devel
+            if found and found.group(2) != 'devel': # second check is to avoid renaming of python2-devel to python-devel
                 return 'python-{0}'.format(regexp.search(name).group(2))
             return name
 
@@ -46,7 +46,8 @@ class NameConvertor(object):
         return versioned_name
 
     def rpm_name(self, name, python_version=None):
-        """Returns name of the package coverted to (possibly) correct package name according to Packaging Guidelines.
+        """Returns name of the package coverted to (possibly) correct package 
+           name according to Packaging Guidelines.
         Args:
             name: name to convert
             python_version: python version for which to retrieve the name of the package
@@ -63,7 +64,7 @@ class NameConvertor(object):
         if not reg_start.search(name.lower()): # prefix python before pkg name (only if it's not prefixed already)
             rpmized_name = 'python-{0}'.format(name)
 
-        reg_end = re.compile(r'(.*)-(python)(\d*|)$')        
+        reg_end = re.compile(r'(.*)-(python)(\d*|)$')
         found_end = reg_end.search(name.lower())
         if found_end: # if package has -pythonXY like sufix convert it to prefix
             rpmized_name = '{0}{1}-{2}'.format('python', found_end.group(3), found_end.group(1))

--- a/pyp2rpm/package_getters.py
+++ b/pyp2rpm/package_getters.py
@@ -62,8 +62,8 @@ class PypiDownloader(PackageGetter):
                     logger.info('Using rpmdevtools package to make rpmbuild folders tree.')
                 except OSError:
                     self.save_dir = '/tmp'  # pyp2rpm can work without rpmdevtools
-                    logger.warn('Package rpmdevtools is missing , using default folder: {0} to store {1}.'.format(
-                        self.save_dir, self.name))
+                    logger.warn('Package rpmdevtools is missing , using default folder: '
+                                '{0} to store {1}.'.format(self.save_dir, self.name))
                     logger.warn('Specify folder to store a file (SAVE_DIR) or install rpmdevtools.')
         logger.info('Using {0} as directory to save source.'.format(self.save_dir))
 

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -1,12 +1,13 @@
 import os
 
 DEFAULT_PYTHON_VERSION = '2'
+DEFAULT_ADDITIONAL_VERSION = '3'
 DEFAULT_PKG_SOURCE = 'pypi'
 DEFAULT_METADATA_SOURCE = 'pypi'
 DEFAULT_TEMPLATE = 'fedora'
 DEFAULT_DISTRO = 'fedora'
 DEFAULT_PKG_SAVE_PATH = os.path.expanduser('~/rpmbuild')
-KNOWN_DISTROS = ['fedora', 'mageia']
+KNOWN_DISTROS = ['fedora', 'mageia', 'pld']
 ARCHIVE_SUFFIXES = ['.tar', '.tgz', '.tar.gz', '.tar.bz2', '.gz', '.bz2', '.zip', '.egg']
 EXTENSION_SUFFIXES = ['.c', '.cpp']
 DOC_FILES_RE = [r'readme.+', r'licens.+', r'copying.+']

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -54,19 +54,21 @@ sphinx-build{% if pv != data.base_python_version %}-{{ pv }}{% endif %} {{ data.
 rm -rf html/.{doctrees,buildinfo}
 {%- endif %}
 {%- endcall %}
+
 %build
 {% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
 pushd python{{ pv }}
 {% if data.has_extension %}CFLAGS="$RPM_OPT_FLAGS" {% endif %}{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py build
 popd
 {%- endcall %}
+
 %install
 {%- if data.python_versions|length > 0 %}
 # Must do the subpackages' install first because the scripts in /usr/bin are
 # overwritten with every setup.py install (and we want the python2 version
 # to be the default for now).
 {%- endif -%}
-{%- call(pv) for_python_versions(data.python_versions + [data.base_python_version], data.base_python_version) -%}
+{%- call(pv) for_python_versions(data.python_versions + [data.base_python_version], data.base_python_version) %}
 pushd python{{ pv }}
 {{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py install --skip-build --root %{buildroot}
 {%- if pv != data.base_python_version %}
@@ -89,7 +91,7 @@ popd
 {%- endif %}
 {% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
 %files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
-%doc {% if data.sphinx_dir %}html {% endif %}python{{ pv }}/{{data.doc_files|join(' python{}/'.format(pv)) }}
+%doc {% if data.sphinx_dir %}html {% endif %} {% if data.doc_files %}python{{ pv }}/{{data.doc_files|join(' python{}/'.format(pv)) }} {%endif %}
 {%- if data.scripts %}
 {%- for script in data.scripts %}
 %{_bindir}/{{ script|script_name_for_python_version(pv) }}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -33,38 +33,33 @@ Summary:        {{ data.summary }}
 %description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
 {{ data.description|truncate(400)|wordwrap }}
 {%- endcall %}
-
 %prep
-%setup -q -n %{pypi_name}-%{version}
+%setup -qc
+mv %{pypi_name}-%{version} python{{ data.base_python_version }}
 {%- if data.has_bundled_egg_info %}
 # Remove bundled egg-info
+pushd python{{ data.base_python_version }}
 rm -rf %{pypi_name}.egg-info
+popd
 {%- endif %}
 {% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
 {%- if pv != data.base_python_version -%}
-rm -rf %{py{{pv}}dir}
-cp -a . %{py{{pv}}dir}
-find %{py{{pv}}dir} -name '*.py' | xargs sed -i '1s|^#!python|#!%{__python{{pv}}}|'
+cp -a python{{ data.base_python_version }} python{{ pv }}
 {%- endif %}
+find python{{pv}} -name '*.py' | xargs sed -i '1s|^#!python|#!%{__python{{pv}}}|'
 {%- if data.sphinx_dir %}
 # generate html docs {# TODO: generate properly for other versions (pushd/popd into their dirs...) #}
 sphinx-build{% if pv != data.base_python_version %}-{{ pv }}{% endif %} {{ data.sphinx_dir }} html
 # remove the sphinx-build leftovers
 rm -rf html/.{doctrees,buildinfo}
 {%- endif %}
-{% endcall %}
-
-%build
-{%- call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
-{%- if pv != data.base_python_version -%}
-pushd %{py{{ pv }}dir}
-{%- endif %}
-{% if data.has_extension %}CFLAGS="$RPM_OPT_FLAGS" {% endif %}{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py build
-{% if pv != data.base_python_version -%}
-popd
-{%- endif %}
 {%- endcall %}
-
+%build
+{% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+pushd python{{ pv }}
+{% if data.has_extension %}CFLAGS="$RPM_OPT_FLAGS" {% endif %}{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py build
+popd
+{%- endcall %}
 %install
 {%- if data.python_versions|length > 0 %}
 # Must do the subpackages' install first because the scripts in /usr/bin are
@@ -72,36 +67,29 @@ popd
 # to be the default for now).
 {%- endif -%}
 {%- call(pv) for_python_versions(data.python_versions + [data.base_python_version], data.base_python_version) -%}
-{%- if pv != data.base_python_version -%}
-pushd %{py{{ pv }}dir}
-{%- endif %}
+pushd python{{ pv }}
 {{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py install --skip-build --root %{buildroot}
 {%- if pv != data.base_python_version %}
 {%- if data.scripts %}
 {%- for script in data.scripts %}
+
 mv %{buildroot}%{_bindir}/{{ script }} %{buildroot}/%{_bindir}/{{ script|script_name_for_python_version(pv) }}
 {%- endfor %}
 {%- endif %}
-popd
 {%- endif %}
+popd
 {%- endcall %}
-
 {% if data.has_test_suite %}
 %check
 {%- call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
-{%- if pv != data.base_python_version -%}
-pushd %{py{{ pv }}dir}
-{%- endif %}
+pushd python{{ pv }}
 {{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py test
-{% if pv != data.base_python_version -%}
 popd
-{%- endif %}
 {%- endcall %}
 {%- endif %}
-
 {% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
 %files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
-%doc {% if data.sphinx_dir %}html {% endif %}{{ data.doc_files|join(' ') }}
+%doc {% if data.sphinx_dir %}html {% endif %}python{{ pv }}/{{data.doc_files|join(' python{}/'.format(pv)) }}
 {%- if data.scripts %}
 {%- for script in data.scripts %}
 %{_bindir}/{{ script|script_name_for_python_version(pv) }}
@@ -134,7 +122,6 @@ popd
 {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
 {%- endif %}
 {%- endcall %}
-
 %changelog
 * {{ data.changelog_date_packager }} - {{ data.version }}-1
 - Initial package.

--- a/pyp2rpm/templates/macros.spec
+++ b/pyp2rpm/templates/macros.spec
@@ -30,11 +30,13 @@ BuildRequires:  {{ 'python-setuptools'|name_for_python_version(python_version) }
 {%- macro for_python_versions(python_versions, base_python_version) %}
 {%- for pv in python_versions %}
 {%- if pv != base_python_version %}
+
 %if 0%{?with_python{{ pv }}}
 {% endif %}
 {{- caller(pv) }}
 {%- if pv != base_python_version %}
 %endif # with_python{{ pv }}
+
 {% endif %}
 {%- endfor %}
 {%- endmacro %}

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -37,7 +37,8 @@ def license_from_trove(trove):
     Args:
         trove: list of trove classifiers
     Returns:
-        Fedora name of the package license or empty string, if no licensing information is found in trove classifiers.
+        Fedora name of the package license or empty string, if no licensing
+        information is found in trove classifiers.
     """
     license = []
     for classifier in trove:
@@ -82,6 +83,7 @@ def build_srpm(specfile, save_dir):
                                     '--define', '_rpmdir {0}'.format(save_dir + '/RPMS'),
                                     '-bs', specfile], stdout=subprocess.PIPE).communicate()[0].strip()
         except OSError:
-            logger.error('Rpmbuild failed for specfile: {0} and save_dir: {1}'.format(specfile, save_dir), exc_info=True)
+            logger.error('Rpmbuild failed for specfile: {0} and save_dir: {1}'.format(
+                specfile, save_dir), exc_info=True)
             msg = 'Rpmbuild failed. See log for more info.'
         return msg


### PR DESCRIPTION
Changes command lines switches to include default Python3 subpackage and updates fedora template to correspond with updated Fedora packaging guidelines. Fixes issues #8 and #9
