### PR TITLE
New fedora template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
+    - "2.6"
     - "2.7"
     - "3.4"
 env:
+    -TOXENV=py26
     -TOXENV=py27
     -TOXENV=py34
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ To run the unit tests, cd into the checked out directory and run::
 or run::
 
     python setup.py test
+    
+Recommended way to use:
+
+![alt tag](https://mcyprian.fedorapeople.org/pyp2rpm_guide2.gif 
+"Record of pyp2rpm usage")
+
 
 I will gladly accept any pull request or recommendation.
 With complex pull requests, please include unit tests in *pytest*, use *flexmock* if you need mocking.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ or run::
     
 Recommended way to use:
 
-![alt tag](https://mcyprian.fedorapeople.org/pyp2rpm_guide2.gif 
+![alt tag](https://mcyprian.fedorapeople.org/pyp2rpm_guide.gif 
 "Record of pyp2rpm usage")
 
 

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -6,11 +6,17 @@ def name_for_python_version(name, version, default_number=False):
     return name_convertor.NameConvertor.rpm_versioned_name(name, version, default_number)
 
 
-def script_name_for_python_version(name, version):
-    if version == settings.DEFAULT_PYTHON_VERSION:
-        return name
+def script_name_for_python_version(name, version, minor=False, default_number=True):
+    if not default_number:
+        if version == settings.DEFAULT_PYTHON_VERSION:
+            return name
+    if minor:
+        if len(version) > 1:
+            return '{0}-{1}'.format(name, '.'.join(list(version)))
+        else:
+            return '{0}-%{{python{1}_version}}'.format(name, version)
     else:
-        return 'python{0}-{1}'.format(version, name)
+        return '{0}-{1}'.format(name, version[0])
 
 
 def sitedir_for_python_version(name, version, default_string='python2'):

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -2,8 +2,8 @@ from pyp2rpm import settings
 from pyp2rpm import name_convertor
 
 
-def name_for_python_version(name, version):
-    return name_convertor.NameConvertor.rpm_versioned_name(name, version)
+def name_for_python_version(name, version, default_number=False):
+    return name_convertor.NameConvertor.rpm_versioned_name(name, version, default_number)
 
 
 def script_name_for_python_version(name, version):
@@ -13,14 +13,14 @@ def script_name_for_python_version(name, version):
         return 'python{0}-{1}'.format(version, name)
 
 
-def sitedir_for_python_version(name, version,default_string='python2'):
+def sitedir_for_python_version(name, version, default_string='python2'):
     if version == settings.DEFAULT_PYTHON_VERSION:
         return name
     else:
         return name.replace(default_string, 'python{0}'.format(version))
 
 
-def python_bin_for_python_version(name, version,default_string='__python2'):
+def python_bin_for_python_version(name, version, default_string='__python2'):
     if version == settings.DEFAULT_PYTHON_VERSION:
         return name
     else:

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -194,7 +194,7 @@ class LocalMetadataExtractor(object):
             else:
                 transformed.append(script[0:equal_sign].strip())
 
-        return map(os.path.basename, transformed)
+        return list(map(os.path.basename, transformed))
 
     @property
     def data_from_archive(self):

--- a/pyp2rpm/name_convertor.py
+++ b/pyp2rpm/name_convertor.py
@@ -13,7 +13,7 @@ class NameConvertor(object):
         self.distro = distro
 
     @staticmethod
-    def rpm_versioned_name(name, version):
+    def rpm_versioned_name(name, version, default_number=False):
         """Properly versions the name.
         For example:
         rpm_versioned_name('python-foo', '26') will return python26-foo
@@ -29,7 +29,7 @@ class NameConvertor(object):
         """
         regexp = re.compile(r'^python(\d*|)-(.*)')
 
-        if not version or version == settings.DEFAULT_PYTHON_VERSION:
+        if not version or version == settings.DEFAULT_PYTHON_VERSION and not default_number:
             found = regexp.search(name)
             if found and found.group(2) != 'devel': # second check is to avoid renaming of python2-devel to python-devel
                 return 'python-{0}'.format(regexp.search(name).group(2))

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -18,7 +18,6 @@ BuildArch:      noarch
 {%- for pv in data.python_versions %}
 {{ dependencies(data.build_deps, False, pv, data.base_python_version, False) }}
 {%- endfor %}
-{{ dependencies(data.runtime_deps, True, data.base_python_version, data.base_python_version) }}
 
 %description
 {{ data.description|truncate(400)|wordwrap }}

--- a/pyp2rpm/templates/fedora_subdirs.spec
+++ b/pyp2rpm/templates/fedora_subdirs.spec
@@ -1,8 +1,11 @@
 {{ data.credit_line }}
 {% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
 %global pypi_name {{ data.name }}
+{%- for pv in data.python_versions %}
+%global with_python{{ pv }} 1
+{%- endfor %}
 
-Name:           {{ data.pkg_name|macroed_pkg_name(data.name) }}
+Name:           {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(data.base_python_version) }}
 Version:        {{ data.version }}
 Release:        1%{?dist}
 Summary:        {{ data.summary }}
@@ -16,59 +19,83 @@ BuildArch:      noarch
 {%- endif %}
 {{ dependencies(data.build_deps, False, data.base_python_version, data.base_python_version) }}
 {%- for pv in data.python_versions %}
-{{ dependencies(data.build_deps, False, pv, data.base_python_version, False) }}
+{{ dependencies(data.build_deps, False, pv, data.base_python_version) }}
 {%- endfor %}
 {{ dependencies(data.runtime_deps, True, data.base_python_version, data.base_python_version) }}
 
 %description
 {{ data.description|truncate(400)|wordwrap }}
-{% for pv in ([data.base_python_version] + data.python_versions) %}
-%package -n     {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }}
+{% call(pv) for_python_versions(data.python_versions) -%}
+%package -n     {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
 Summary:        {{ data.summary }}
-%{?python_provide:%python_provide python{{ pv }}-%{pypi_name}}
 {{ dependencies(data.runtime_deps, True, pv, pv) }}
-%description -n {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }}
+
+%description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
 {{ data.description|truncate(400)|wordwrap }}
-{% endfor -%}
+{%- endcall %}
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%setup -qc
+mv %{pypi_name}-%{version} python{{ data.base_python_version }}
 {%- if data.has_bundled_egg_info %}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
 {%- endif %}
-{% for pv in ([data.base_python_version] + data.python_versions) -%}
-{%- if data.sphinx_dir-%}
+{% if data.doc_files -%}
+pushd python{{ data.base_python_version }}
+# copy common doc files to top dir to reference them using %%doc later
+cp -pr {{data.doc_files|join(' ') }} ../
+popd
+{%- endif %}
+{% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+{%- if pv != data.base_python_version -%}
+cp -a python{{ data.base_python_version }} python{{ pv }}
+{%- endif %}
+find python{{pv}} -name '*.py' | xargs sed -i '1s|^#!python|#!%{__python{{pv}}}|'
+{%- if data.sphinx_dir %}
 # generate html docs {# TODO: generate properly for other versions (pushd/popd into their dirs...) #}
 sphinx-build{% if pv != data.base_python_version %}-{{ pv }}{% endif %} {{ data.sphinx_dir }} html
 # remove the sphinx-build leftovers
 rm -rf html/.{doctrees,buildinfo}
 {%- endif %}
-{%- endfor %}
+{%- endcall %}
+
 %build
-{%- for pv in [data.base_python_version] + data.python_versions %}
-%py{{ pv }}_build
-{%- endfor %}
+{% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+pushd python{{ pv }}
+{% if data.has_extension %}CFLAGS="$RPM_OPT_FLAGS" {% endif %}{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py build
+popd
+{% endcall %}
 
 %install
 {%- if data.python_versions|length > 0 %}
 # Must do the subpackages' install first because the scripts in /usr/bin are
 # overwritten with every setup.py install (and we want the python2 version
 # to be the default for now).
-{%- for pv in data.python_versions %}
-%py{{ pv }}_install
-{%- endfor -%}
-{%- endif %}
-%py{{ data.base_python_version}}_install
-{% if data.has_test_suite %}
+{%- endif -%}
+{%- call(pv) for_python_versions(data.python_versions + [data.base_python_version], data.base_python_version) %}
+pushd python{{ pv }}
+{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py install --skip-build --root %{buildroot}
+{%- if pv != data.base_python_version %}
+{%- if data.scripts %}
+{%- for script in data.scripts %}
 
-%check
-{%- for pv in [data.base_python_version] + data.python_versions %}
-%{__python{{ pv }}} setup.py test
+mv %{buildroot}%{_bindir}/{{ script }} %{buildroot}/%{_bindir}/{{ script|script_name_for_python_version(pv) }}
 {%- endfor %}
 {%- endif %}
-{% for pv in [data.base_python_version] + data.python_versions %}
-%files -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }} 
-%doc {% if data.sphinx_dir %}html {% endif %}{{data.doc_files|join(' ') }}
+{%- endif %}
+popd
+{%- endcall %}
+{% if data.has_test_suite %}
+%check
+{%- call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+pushd python{{ pv }}
+{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py test
+popd
+{%- endcall %}
+{%- endif %}
+{% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
+%doc {% if data.sphinx_dir %}html {% endif %} {{data.doc_files|join(' ') }}
 {%- if data.scripts %}
 {%- for script in data.scripts %}
 %{_bindir}/{{ script|script_name_for_python_version(pv) }}
@@ -100,7 +127,7 @@ rm -rf html/.{doctrees,buildinfo}
 {%- endif %}
 {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
 {%- endif %}
-{% endfor %}
+{% endcall %}
 %changelog
 * {{ data.changelog_date_packager }} - {{ data.version }}-1
 - Initial package.

--- a/pyp2rpm/templates/macros.spec
+++ b/pyp2rpm/templates/macros.spec
@@ -7,9 +7,10 @@
    considering the base_python_version. #}
 {# This cannot be implemented by macro for_python_versions because it needs to
    decide on its own, whether to even use the %if 0%{?with_pythonX} or not. #}
-{%- macro dependencies(deps, runtime, python_version, base_python_version) %}
+{%- macro dependencies(deps, runtime, python_version, base_python_version,
+use_with=True) %}
 {%- if deps|length > 0 or not runtime %} {# for build deps, we always have at least 1 - pythonXX-devel #}
-{%- if python_version != base_python_version %}
+{%- if python_version != base_python_version and use_with %}
 %if %{?with_python{{ python_version }}}
 {%- endif %}
 {%- if not runtime %}
@@ -19,7 +20,7 @@ BuildRequires:  {{ 'python-setuptools'|name_for_python_version(python_version) }
 {%- for dep in deps -%}
 {{ one_dep(dep, python_version) }}
 {%- endfor %}
-{%- if python_version != base_python_version%}
+{%- if python_version != base_python_version and use_with %}
 %endif # if with_python{{ python_version }}
 {%- endif %}
 {%- endif %}
@@ -30,13 +31,11 @@ BuildRequires:  {{ 'python-setuptools'|name_for_python_version(python_version) }
 {%- macro for_python_versions(python_versions, base_python_version) %}
 {%- for pv in python_versions %}
 {%- if pv != base_python_version %}
-
 %if 0%{?with_python{{ pv }}}
 {% endif %}
 {{- caller(pv) }}
 {%- if pv != base_python_version %}
 %endif # with_python{{ pv }}
-
 {% endif %}
 {%- endfor %}
 {%- endmacro %}

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34
+envlist = py26, py27, py34
 
 [testenv]
 deps = 
     setuptools 
     flexmock
 
+commands = python setup.py test
+
+[testenv :py26]
+basepython=python2.6
 commands = python setup.py test
 
 [testenv :py27]


### PR DESCRIPTION
Packaging Python guidelines now recommends to build both python2 and python3 versions in the same directory and to use new %py2_build and %py2_install macros. This PR adds new fedora template and moves the old to file fedora_subdirs.spec.
