### PR TITLE
Virtualenv module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "3.4"
-env:
-    -TOXENV=py26
-    -TOXENV=py27
-    -TOXENV=py34
+matrix:
+    include:
+        - python: "2.6"
+          env: TOXENV=py26
+        - python: "2.7"
+          env: TOXENV=py27
+        - python: "3.4"
+          env: TOXENV=py34
+install:
+    - pip install tox
 
-# command to install dependencies
-install: "pip install -U tox"
-# command to run tests
-script: tox -e $TOXENV
+script: tox
+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+2.0.0
+* Added default python3 subpackage, testing tools tox and travis
+* Small change in command line switches
+* Improved documentation
+* Updated fedora template to comply with newest packaging guidelines
+* Old template renamed to fedora_subdirs.spec
+
 1.1.2
 * Use python2-devel instead of python-devel
 * Support Python2.6

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -159,7 +159,8 @@ class Convertor(object):
                     self.name_convertor,
                     self.version,
                     self.client,
-                    self.rpm_name)
+                    self.rpm_name,
+                    self.base_python_version)
             else:
                 logger.info('Getting metadata from local file.')
                 self._metadata_extractor = metadata_extractors.LocalMetadataExtractor(

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -49,7 +49,9 @@ class Convertor(object):
         self.rpm_name = rpm_name
         self.proxy = proxy
         self.pypi = True
-        if os.path.exists(self.package):
+        suffix = os.path.splitext(self.package)[1]
+        if os.path.exists(self.package) and suffix in settings.ARCHIVE_SUFFIXES\
+            and not os.path.isdir(self.package):
             self.pypi = False
 
 

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -110,7 +110,7 @@ class Convertor(object):
                 self._getter = package_getters.LocalFileGetter(
                     self.package,
                     self.save_dir)
-                logger.debug('{} doesnt exists as local file trying PyPI.'.format(self.package))
+                logger.debug('{0} doesnt exists as local file trying PyPI.'.format(self.package))
             else:
                 self._getter = package_getters.PypiDownloader(
                     self.client,

--- a/pyp2rpm/exceptions.py
+++ b/pyp2rpm/exceptions.py
@@ -12,3 +12,6 @@ class NoSuchPackageException(BaseException):
 
 class NoSuchSourceException(BaseException):
     pass
+
+class VirtualenvFailException(BaseException):
+    pass

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -214,10 +214,14 @@ class LocalMetadataExtractor(object):
         archive_data['has_pth'] = self.has_pth
         if self.archive.is_egg:
             archive_data['runtime_deps'] = self.runtime_deps_from_egg_info
-            archive_data['build_deps'] = self.build_deps_from_egg_info
+            archive_data['build_deps'] = [['BuildRequires', 'python2-devel'],
+                                          ['BuildRequires', 'python-setuptools']]\
+                                         + self.build_deps_from_egg_info
         else:
             archive_data['runtime_deps'] = self.runtime_deps_from_setup_py
-            archive_data['build_deps'] = self.build_deps_from_setup_py
+            archive_data['build_deps'] = [['BuildRequires', 'python2-devel'],
+                                          ['BuildRequires', 'python-setuptools']]\
+                                         + self.build_deps_from_setup_py
 
         sphinx_dir = self.sphinx_dir
         if sphinx_dir:
@@ -264,6 +268,8 @@ class LocalMetadataExtractor(object):
         with self.archive:
             data.set_from(self.data_from_archive)
 
+        data.data['build_deps'] += utils.runtime_to_build(data.data['runtime_deps'])
+        setattr(data, "build_deps", utils.unique_deps(data.data['build_deps']))
         # for example nose has attribute `packages` but instead of name listing the pacakges
         # is using function to find them, that makes data.packages an empty set
         if data.has_packages and not data.packages:
@@ -409,7 +415,9 @@ class _WheelMetadataExtractor(PypiMetadataExtractor):
         archive_data['doc_files'] = self.doc_files
         archive_data['has_pth'] = self.has_pth
         archive_data['runtime_deps'] = self.runtime_deps
-        archive_data['build_deps'] = self.build_deps
+        archive_data['build_deps'] = [['BuildRequires', 'python2-devel'],
+                                      ['BuildRequires', 'python-setuptools']]\
+                                     + self.build_deps
         sphinx_dir = self.sphinx_dir
         if sphinx_dir:
             archive_data['sphinx_dir'] = "/".join(sphinx_dir.split("/")[1:])

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -329,6 +329,7 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
             data.set_from(self.data_from_archive)
 
         data.set_from(self.data_from_venv, update=True)
+        setattr(data, "scripts", utils.remove_major_minor_suffix(data.data['scripts']))
       
         # for example nose has attribute `packages` but instead of name listing the
         # packages is using function to find them, that makes data.packages an empty set

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -326,8 +326,8 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
             data.set_from(self.data_from_archive)
 
         data.set_from(self.data_from_venv, update=True)
-        
-                # for example nose has attribute `packages` but instead of name listing the
+      
+        # for example nose has attribute `packages` but instead of name listing the
         # packages is using function to find them, that makes data.packages an empty set
         if data.has_packages and not data.packages:
             data.packages.add(data.name)

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 import shutil
+import itertools
 
 from pyp2rpm import archive
 from pyp2rpm import virtualenv
@@ -330,7 +331,11 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
 
         data.set_from(self.data_from_venv, update=True)
         setattr(data, "scripts", utils.remove_major_minor_suffix(data.data['scripts']))
-      
+        
+        data.data['build_deps'] += utils.runtime_to_build(data.data['runtime_deps'])
+        setattr(data, "build_deps", utils.unique_deps(data.data['build_deps']))
+        # Append all runtime deps to build deps and unique the result
+
         # for example nose has attribute `packages` but instead of name listing the
         # packages is using function to find them, that makes data.packages an empty set
         if data.has_packages and not data.packages:

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -246,7 +246,9 @@ class LocalMetadataExtractor(object):
         """
         temp_dir = tempfile.mkdtemp()
         try:
-            extractor = virtualenv.VirtualEnv(self.name, temp_dir, self.name_convertor)
+            extractor = virtualenv.VirtualEnv(self.name, temp_dir,
+                                              self.name_convertor, 
+                                              self.base_python_version)
             return extractor.get_venv_data
         except VirtualenvFailException:
              logger.error("Skipping virtualenv metadata extraction")
@@ -281,10 +283,11 @@ class LocalMetadataExtractor(object):
 class PypiMetadataExtractor(LocalMetadataExtractor):
 
     def __init__(self, local_file, name, name_convertor, version, client,
-                 rpm_file=None):
+                 rpm_file=None, base_python_version=settings.DEFAULT_PYTHON_VERSION):
         super(PypiMetadataExtractor, self).__init__(
             local_file, name, name_convertor, version, rpm_file)
         self.client = client
+        self.base_python_version = base_python_version
 
     def extract_data(self):
         """Extracts data from PyPI and archive.

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import shutil
 
 from pyp2rpm import archive
 from pyp2rpm import virtualenv
@@ -238,13 +239,15 @@ class LocalMetadataExtractor(object):
         Returns:
             dictionary containing metadata extracted from virtualenv
         """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            try:
-                extractor = virtualenv.VirtualEnv(self.name, temp_dir, self.name_convertor)
-            except VirtualenvFailException:
-                logger.error("Skipping virtualenv metadata extraction")
-                return {}
+        temp_dir = tempfile.mkdtemp()
+        try:
+            extractor = virtualenv.VirtualEnv(self.name, temp_dir, self.name_convertor)
             return extractor.get_venv_data
+        except VirtualenvFailException:
+             logger.error("Skipping virtualenv metadata extraction")
+             return {}
+        finally:
+            shutil.rmtree(temp_dir)
 
     def extract_data(self):
         """Extracts data from archive.

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -240,7 +240,7 @@ class LocalMetadataExtractor(object):
             dictionary containing metadata extracted from virtualenv
         """
         with tempfile.TemporaryDirectory() as temp_dir:
-            extractor = virtualenv.VirtualEnv(self.name, temp_dir)
+            extractor = virtualenv.VirtualEnv(self.name, temp_dir, self.name_convertor)
             return extractor.get_venv_data
 
     def extract_data(self):
@@ -327,7 +327,7 @@ class PypiMetadataExtractor(LocalMetadataExtractor):
             if key != 'description':
                 print("{}   {}".format(key, value))
 
-        data.set_from(self.data_from_venv)
+        data.set_from(self.data_from_venv, update=True)
         
         print("\nAFTER VENV")
         for key, value in data.data.items():

--- a/pyp2rpm/package_data.py
+++ b/pyp2rpm/package_data.py
@@ -38,9 +38,27 @@ class PackageData(object):
         if value is not None:
             self.data[name] = value
 
-    def set_from(self, data_dict):
+    def update_attr(self, name, value):
+        if name in self.data and value:
+            if name == 'runtime_deps': # data['runtime_deps'] is list of the lists
+                for item in value:
+                    if item not in self.data[name]:
+                        self.data[name].append(item)
+            elif isinstance(self.data[name], list):
+                if not value in self.data[name]:
+                    self.data[name] += value
+            elif isinstance(self.data[name], set):
+                self.data[name] |= value
+        elif value:
+            self.data[name] = value
+
+    def set_from(self, data_dict, update=False):
         for k, v in data_dict.items():
-            setattr(self, k, v)
+            if update:
+                self.update_attr(k, v)
+            else:
+                setattr(self, k, v)
+    
 
     def get_changelog_date_packager(self):
         """Returns part of the changelog entry, containing date and packager.

--- a/pyp2rpm/package_data.py
+++ b/pyp2rpm/package_data.py
@@ -8,6 +8,13 @@ from pyp2rpm import utils
 
 logger = logging.getLogger(__name__)
 
+def get_deps_names(runtime_deps_list):
+    '''
+    data['runtime_deps'] has format:
+    [['Requires', 'name', '>=', 'version'], ...]
+    this function creates list of lowercase deps names
+    '''
+    return [x[1].lower() for x in runtime_deps_list]
 
 class PackageData(object):
     credit_line = '# Created by pyp2rpm-{0}'.format(version.version)
@@ -40,13 +47,14 @@ class PackageData(object):
 
     def update_attr(self, name, value):
         if name in self.data and value:
-            if name == 'runtime_deps': # data['runtime_deps'] is list of the lists
+            if name == 'runtime_deps':  # compare lowercase names of deps
+                for item in value:
+                    if not item[1].lower() in get_deps_names(self.data[name]):
+                        self.data[name].append(item)
+            elif isinstance(self.data[name], list):
                 for item in value:
                     if item not in self.data[name]:
                         self.data[name].append(item)
-            elif isinstance(self.data[name], list):
-                if not value in self.data[name]:
-                    self.data[name] += value
             elif isinstance(self.data[name], set):
                 self.data[name] |= value
         elif value:

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -8,6 +8,7 @@ DEFAULT_TEMPLATE = 'fedora'
 DEFAULT_DISTRO = 'fedora'
 DEFAULT_PKG_SAVE_PATH = os.path.expanduser('~/rpmbuild')
 KNOWN_DISTROS = ['fedora', 'mageia', 'pld']
+VENV_INTERPRETER = '/usr/bin/python3.4'
 ARCHIVE_SUFFIXES = ['.tar', '.tgz', '.tar.gz', '.tar.bz2', '.gz', '.bz2', '.zip', '.egg']
 EXTENSION_SUFFIXES = ['.c', '.cpp']
 DOC_FILES_RE = [r'readme.+', r'licens.+', r'copying.+']

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -8,7 +8,6 @@ DEFAULT_TEMPLATE = 'fedora'
 DEFAULT_DISTRO = 'fedora'
 DEFAULT_PKG_SAVE_PATH = os.path.expanduser('~/rpmbuild')
 KNOWN_DISTROS = ['fedora', 'mageia', 'pld']
-VENV_INTERPRETER = '/usr/bin/python3.4'
 ARCHIVE_SUFFIXES = ['.tar', '.tgz', '.tar.gz', '.tar.bz2', '.gz', '.bz2', '.zip', '.egg']
 EXTENSION_SUFFIXES = ['.c', '.cpp']
 DOC_FILES_RE = [r'readme.+', r'licens.+', r'copying.+']

--- a/pyp2rpm/templates/macros.spec
+++ b/pyp2rpm/templates/macros.spec
@@ -15,7 +15,6 @@ use_with=True) %}
 {%- endif %}
 {%- if not runtime %}
 BuildRequires:  {{ 'python2-devel'|name_for_python_version(python_version) }}
-BuildRequires:  {{ 'python-setuptools'|name_for_python_version(python_version) }}
 {%- endif %}
 {%- for dep in deps -%}
 {{ one_dep(dep, python_version) }}

--- a/pyp2rpm/templates/macros.spec
+++ b/pyp2rpm/templates/macros.spec
@@ -13,9 +13,6 @@ use_with=True) %}
 {%- if python_version != base_python_version and use_with %}
 %if %{?with_python{{ python_version }}}
 {%- endif %}
-{%- if not runtime %}
-BuildRequires:  {{ 'python2-devel'|name_for_python_version(python_version) }}
-{%- endif %}
 {%- for dep in deps -%}
 {{ one_dep(dep, python_version) }}
 {%- endfor %}

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 import re
+import copy
+import itertools
 
 from pyp2rpm import settings
 
@@ -93,3 +95,16 @@ def remove_major_minor_suffix(scripts):
     """Checks if executables already contain a "-MAJOR.MINOR" suffix. """
     minor_major_regex = re.compile("-\d.?\d?$")
     return [x for x in scripts if not minor_major_regex.search(x)]
+
+def runtime_to_build(runtime_deps):
+    """Adds all runtime deps to build deps"""
+    build_deps = copy.deepcopy(runtime_deps)
+    for dep in build_deps:
+        if len(dep) > 0:
+            dep[0] = 'BuildRequires'
+    return build_deps
+
+def unique_deps(deps):
+    """Remove duplicities from deps list of the lists"""
+    deps.sort()
+    return list(k for k, _ in itertools.groupby(deps))

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 import subprocess
 import sys
+import re
 
 from pyp2rpm import settings
 
@@ -87,3 +88,8 @@ def build_srpm(specfile, save_dir):
                 specfile, save_dir), exc_info=True)
             msg = 'Rpmbuild failed. See log for more info.'
         return msg
+
+def remove_major_minor_suffix(scripts):
+    """Checks if executables already contain a "-MAJOR.MINOR" suffix. """
+    minor_major_regex = re.compile("-\d.?\d?$")
+    return [x for x in scripts if not minor_major_regex.search(x)]

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -109,7 +109,7 @@ class VirtualEnv(object):
         formated_deps = []
         for dep in deps_list:
             name = self.name_convertor.rpm_name(dep[0])
-            formated_deps.append(['Requires', name])
+            formated_deps.append(['Requires', name.lower()])
         return formated_deps
 
     @property

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 def site_packages_filter(site_packages_list):
     '''Removes wheel .dist-info files'''
-    return {x for x in site_packages_list if not x.split('.')[-1] == 'dist-info'}
+    return set([x for x in site_packages_list if not x.split('.')[-1] ==
+        'dist-info'])
 
 def deps_package_filter(deps_list, package):
     '''

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -27,6 +27,11 @@ def deps_wheel_filter(deps_list):
     '''
     return [x for x in deps_list if not x[0] == 'wheel']
 
+def scripts_filter(scripts):
+    '''
+    Removes .pyc files from scripts
+    '''
+    return [x for x in scripts if not x.split('.')[-1] == 'pyc']
 
 class DirsContent(object):
     '''
@@ -137,7 +142,7 @@ class VirtualEnv(object):
         site_packages = site_packages_filter(diff.lib_sitepackages)
         logger.debug('Site_packages from files differance in virtualenv: {0}.'.format(
             site_packages))
-        scripts = list(diff.bindir)
+        scripts = scripts_filter(list(diff.bindir))
         logger.debug('Scripts from files differance in virtualenv: {0}.'.format(scripts))
         return (site_packages, scripts)
 

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -1,0 +1,120 @@
+import os
+from subprocess import Popen, PIPE
+
+from pyp2rpm.settings import VENV_INTERPRETER
+
+PYTHON_VERSION = VENV_INTERPRETER.split('/')[-1]
+
+def site_packages_filter(site_packages_list):
+    '''Removes wheel .dist-info files'''
+    return [x for x in site_packages_list if not x.split('.')[-1] == 'dist-info']
+    
+def deps_package_filter(deps_list, package):
+    '''
+    Removes package name from all installed packages to 
+    get dependencies
+    '''
+    return [x for x in deps_list if not x.split('==')[0].lower() == package.lower()]
+
+def deps_wheel_filter(deps_list):
+    return [x for x in deps_list if not x.split('==')[0] == 'wheel']
+
+def change_deps_format(deps_list):
+    '''
+    Changes format of runtime deps to match format of archive 
+    data runtime deps
+    '''
+    formated_deps = []
+    for dep in deps_list:
+        name, version = dep.split('==')
+    formated_deps.append(['Requires', name, '>=', version]) # TODO name_convertor
+    return formated_deps
+
+
+class DirsContent(object):
+    '''
+    Object to store and compare directory content before and 
+    after instalation.
+    '''
+    def __init__(self, bindir=set(), lib_sitepackages=set(), lib64_sitepackages=set()):
+        self.bindir = bindir
+        self.lib_sitepackages = lib_sitepackages
+
+    def fill(self, path):
+        '''
+        Scans content of directories
+        '''
+        self.bindir = set(os.listdir(path + 'bin/'))
+        self.lib_sitepackages = set(os.listdir(path + 'lib/' + PYTHON_VERSION + '/site-packages/'))
+    
+    def __sub__(self, other):
+       '''
+       Makes differance of DirsContents objects attributes
+       '''
+       result = DirsContent(
+           self.bindir - other.bindir,
+           self.lib_sitepackages - other.lib_sitepackages)
+       return result
+
+
+class VirtualEnv(object):
+
+    def __init__(self, name, temp_dir):
+        self.name = name
+        self.temp_dir = temp_dir
+        self.create_virtualenv()
+        self.dirs_before_install = DirsContent()
+        self.dirs_after_install = DirsContent()
+        self.dirs_before_install.fill(self.temp_dir + '/venv/')
+        self.data = {}
+
+    def create_virtualenv(self):
+        '''
+        Creates new virtualenv in temp_dir
+        '''
+        proc = Popen(['virtualenv', '-p', VENV_INTERPRETER, self.temp_dir + '/venv/'], stdout=PIPE)
+        proc.communicate()
+        if proc.returncode != 0:
+            pass # TODO error handle output to log??
+
+    def install_package_to_venv(self):
+        '''
+        Installs package given as first argument to virtualenv
+        '''
+        proc = Popen([self.temp_dir + "/venv/bin/pip", "install", "--egg", self.name], stdout=PIPE)
+        proc.communicate()
+        if proc.returncode != 0:
+            pass # TODO error handle
+
+    def uninstall_deps_from_venv(self):
+        '''
+        Removes all dependencies from virtualenv to get only files of packages
+        '''
+        proc = Popen([self.temp_dir + "/venv/bin/pip", "uninstall", "-y"] + self.installed_deps, stdout=PIPE)
+        proc.communicate()
+        if proc.returncode != 0:
+            pass # TODO handle error
+        self.dirs_after_install.fill(self.temp_dir + '/venv/')
+
+    def get_pip_freeze(self):
+        '''
+        Gets all packages installed to venv using pip freeze, filters package
+        name and wheel to get real dependancies
+        '''
+        proc = Popen([self.temp_dir + '/venv/bin/pip', 'freeze'], stdout=PIPE)
+        pip_freeze = proc.stdout.read().decode('utf-8').splitlines()
+        self.installed_deps = deps_package_filter(pip_freeze, self.name)
+        self.data['runtime_deps'] = change_deps_format(deps_wheel_filter(self.installed_deps))
+
+    def get_dirs_differance(self):
+        diff =  self.dirs_after_install - self.dirs_before_install
+        self.data['site_packages'] = site_packages_filter(diff.lib_sitepackages)
+        self.data['scripts'] = list(diff.bindir)
+
+    @property
+    def get_venv_data(self):
+        self.install_package_to_venv()
+        self.get_pip_freeze()
+        self.uninstall_deps_from_venv()
+        self.get_dirs_differance()
+        return self.data

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -105,9 +105,8 @@ class VirtualEnv(object):
             return []
         formated_deps = []
         for dep in deps_list:
-            name = dep[0]
-        name = self.name_convertor.rpm_name(name)
-        formated_deps.append(['Requires', name])
+            name = self.name_convertor.rpm_name(dep[0])
+            formated_deps.append(['Requires', name])
         return formated_deps
 
     @property

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -4,7 +4,6 @@ import logging
 from virtualenvapi.manage import VirtualEnvironment
 import virtualenvapi.exceptions as ve
 
-from pyp2rpm.settings import DEFAULT_PYTHON_VERSION
 from pyp2rpm.exceptions import VirtualenvFailException
 
 logger = logging.getLogger(__name__)
@@ -64,11 +63,11 @@ class DirsContent(object):
 
 class VirtualEnv(object):
 
-    def __init__(self, name, temp_dir, name_convertor):
+    def __init__(self, name, temp_dir, name_convertor, base_python_version):
         self.name = name
         self.temp_dir = temp_dir
         self.name_convertor = name_convertor
-        python_version = 'python' + DEFAULT_PYTHON_VERSION
+        python_version = 'python' + base_python_version
         self.env = VirtualEnvironment(temp_dir + '/venv', python=python_version)
         try:
             self.env.open_or_create()

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=['Jinja2',
                       'setuptools',
                       'click',
+                      'virtualenv-api',
                       ],
     setup_requires=['setuptools',
                     'flexmock >= 0.9.3',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,3 +26,14 @@ class TestUtils(object):
     ])
     def test_license_from_trove(self, input, expected):
         assert utils.license_from_trove(input) == expected
+
+    @pytest.mark.parametrize(('input', 'expected'), [
+        (['script', 'script2', 'script-0.1'], ['script', 'script2']),
+        ([], []),
+        (['script-a'], ['script-a']),
+        (['script-3', 'script-3.4'], []),
+        (['script-3.4'], []),
+    ])
+    def test_remove_major_minor_suffix(self, input, expected):
+        assert utils.remove_major_minor_suffix(input) == expected
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,3 +37,32 @@ class TestUtils(object):
     def test_remove_major_minor_suffix(self, input, expected):
         assert utils.remove_major_minor_suffix(input) == expected
 
+    @pytest.mark.parametrize(('input', 'expected'), [
+        ([['Requires', 'pkg'], ['Requires', 'pkg2']],
+         [['BuildRequires', 'pkg'], ['BuildRequires', 'pkg2']]),
+        ([['Requires', 'pkg', '>=', '1.4.29'], ['Requires', 'python-setuptools']], 
+         [['BuildRequires', 'pkg', '>=', '1.4.29'], ['BuildRequires',
+             'python-setuptools']]),
+         ([], []),
+         ([[], []], [[], []]),
+    ])
+    def test_runtime_to_build(self, input, expected):
+        assert utils.runtime_to_build(input) == expected
+
+    @pytest.mark.parametrize(('input', 'expected'), [
+        ([['Requires', 'pkg'], ['Requires', 'pkg']], [['Requires', 'pkg']]),
+        ([['Requires', 'pkg']], [['Requires', 'pkg']]),
+        ([['Requires', 'pkg'], ['Requires', 'pkg2'], ['Requires', 'pkg']],
+         [['Requires', 'pkg'], ['Requires', 'pkg2']]),
+        ([], []),
+        ([[], []], [[]]),
+        ([[1], [2], [3], [2]], [[1], [2], [3]]),
+    ])
+    def test_unique_deps(self, input, expected):
+        assert utils.unique_deps(input) == expected
+
+
+
+
+
+

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -5,7 +5,7 @@ import tempfile
 from flexmock import flexmock
 from pyp2rpm.virtualenv import *
 from pyp2rpm.name_convertor import NameConvertor
-from pyp2rpm.settings import DEFAULT_DISTRO
+from pyp2rpm.settings import DEFAULT_DISTRO, DEFAULT_PYTHON_VERSION
 
 class TestUtils(object):
     @pytest.mark.parametrize(('input', 'expected'), [
@@ -70,7 +70,9 @@ class TestDirsContent(object):
 class TestVirtualEnv(object):
     def setup_method(self, method):
         self.temp_dir = tempfile.mkdtemp()
-        self.venv = VirtualEnv(None, self.temp_dir, NameConvertor(DEFAULT_DISTRO))
+        self.venv = VirtualEnv(None, self.temp_dir,
+                               NameConvertor(DEFAULT_DISTRO),
+                               DEFAULT_PYTHON_VERSION)
 
     def teardown_method(self, method):
         shutil.rmtree(self.temp_dir)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -40,17 +40,17 @@ class TestUtils(object):
 
 class TestDirsContent(object):
     @pytest.mark.parametrize(('before', 'after', 'expected'), [
-        ({'activate', 'pip'}, {'activate', 'pip', 'foo'}, {'foo'}),
-        ({'activate', 'pip'}, {'activate', 'pip'}, set()),
+        (set(['activate', 'pip']), set(['activate', 'pip', 'foo']), set(['foo'])),
+        (set(['activate', 'pip']), set(['activate', 'pip']), set()),
     ])
     def test_sub_bin(self, before, after, expected):
         result = DirsContent(bindir=after) - DirsContent(bindir=before)
         assert result.bindir == expected
      
     @pytest.mark.parametrize(('before', 'after', 'expected'), [
-        ({'setuptools', 'pip'}, {'setuptools', 'pip', 'foo'}, {'foo'}),
-        ({'wheel', 'pip'}, {'foo', 'pip'}, {'foo'}),
-        ({'wheel', 'pip'}, {'pip'}, set()),
+        (set(['setuptools', 'pip']), set(['setuptools', 'pip', 'foo']), set(['foo'])),
+        (set(['wheel', 'pip']), set(['foo', 'pip']), set(['foo'])),
+        (set(['wheel', 'pip']), set(['pip']), set()),
     ])
     def test_sub_sitepackages(self, before, after, expected):
         result = DirsContent(lib_sitepackages=after) - DirsContent(lib_sitepackages=before)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 from flexmock import flexmock
-
 from pyp2rpm.virtualenv import *
 from pyp2rpm.name_convertor import NameConvertor
 from pyp2rpm.settings import DEFAULT_DISTRO
@@ -12,8 +11,8 @@ class TestUtils(object):
     @pytest.mark.parametrize(('input', 'expected'), [
         (['foo', 'foo-1.0.0.dist-info'], set(['foo'])),
         (['foo', 'foo-1.0.0.dist-info', 'foo2'], set(['foo', 'foo2'])),
-        (['foo', 'foo-1.0.0.dist-info', 'foo2-1.0.0-py2.7.egg-info'], 
-            set(['foo', 'foo2-1.0.0-py2.7.egg-info'])),
+        (['foo', 'foo-1.0.0.dist-info', 'foo2-1.0.0-py2.7.egg-info'],
+         set(['foo', 'foo2-1.0.0-py2.7.egg-info'])),
         (['foo', 'foo2-1.0.0-py2.7.egg-info'], set(['foo', 'foo2-1.0.0-py2.7.egg-info'])),
         ([], set()),
     ])
@@ -22,12 +21,12 @@ class TestUtils(object):
 
     @pytest.mark.parametrize(('deps_list', 'package', 'expected'), [
         ([('foo', '1.0'), ('dep1', '1.0')], 'fOO', [('dep1', '1.0')]),
-        ([('Foo', '1.0'), ('dep1', '1.0'), ('dep2', '1.0')], 'foo', 
-            [('dep1', '1.0'), ('dep2', '1.0')]),
+        ([('Foo', '1.0'), ('dep1', '1.0'), ('dep2', '1.0')], 'foo',
+         [('dep1', '1.0'), ('dep2', '1.0')]),
     ])
     def test_deps_package_filter(self, deps_list, package, expected):
         assert deps_package_filter(deps_list, package) == expected
-    
+
     @pytest.mark.parametrize(('input', 'expected'), [
         ([('foo', '1.0'), ('wheel', '0.24.0')], [('foo', '1.0')]),
         ([('foo', '1.0'), ('foo2', '1.0')], [('foo', '1.0'), ('foo2', '1.0')]),
@@ -44,22 +43,27 @@ class TestDirsContent(object):
         (set(['activate', 'pip']), set(['activate', 'pip']), set()),
     ])
     def test_sub_bin(self, before, after, expected):
-        result = DirsContent(bindir=after) - DirsContent(bindir=before)
+        result = DirsContent(bindir=after, lib_sitepackages=set([])) -\
+        DirsContent(bindir=before, lib_sitepackages=set([]))
         assert result.bindir == expected
-     
+
     @pytest.mark.parametrize(('before', 'after', 'expected'), [
         (set(['setuptools', 'pip']), set(['setuptools', 'pip', 'foo']), set(['foo'])),
         (set(['wheel', 'pip']), set(['foo', 'pip']), set(['foo'])),
         (set(['wheel', 'pip']), set(['pip']), set()),
     ])
     def test_sub_sitepackages(self, before, after, expected):
-        result = DirsContent(lib_sitepackages=after) - DirsContent(lib_sitepackages=before)
+        result = DirsContent(lib_sitepackages=after, bindir=set([])) -\
+        DirsContent(lib_sitepackages=before, bindir=set([]))
         assert result.lib_sitepackages == expected
 
 class TestVirtualEnv(object):
     def setup_method(self, method):
         self.temp_dir = tempfile.mkdtemp()
         self.venv = VirtualEnv(None, self.temp_dir, NameConvertor(DEFAULT_DISTRO))
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
 
     @pytest.mark.parametrize(('input', 'expected'), [
         ([('foo', '1.0')], [['Requires', 'python-foo']]),
@@ -68,7 +72,7 @@ class TestVirtualEnv(object):
     ])
     def test_change_deps_format(self, input, expected):
         flexmock(NameConvertor).should_receive('rpm_name').replace_with(lambda
-                x: 'python-' + x)
+            x: 'python-' + x)
         assert self.venv.change_deps_format(input) == expected
 
     @pytest.mark.parametrize(('bin_diff', 'package_diff', 'expected'), [

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -36,6 +36,16 @@ class TestUtils(object):
     def test_deps_wheel_filter(self, input, expected):
         assert deps_wheel_filter(input) == expected
 
+    @pytest.mark.parametrize(('input', 'expected'), [
+        (['script', 'script2'], ['script', 'script2']),
+        (['script.py', 'script2'], ['script.py', 'script2']),
+        (['script.pyc', 'script2'], ['script2']),
+        (['script.pyc'], []),
+        ([], []),
+    ])
+    def test_scripts_filter(self, input, expected):
+        assert scripts_filter(input) == expected
+
 
 class TestDirsContent(object):
     @pytest.mark.parametrize(('before', 'after', 'expected'), [

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -70,3 +70,12 @@ class TestVirtualEnv(object):
         flexmock(NameConvertor).should_receive('rpm_name').replace_with(lambda
                 x: 'python-' + x)
         assert self.venv.change_deps_format(input) == expected
+
+    @pytest.mark.parametrize(('bin_diff', 'package_diff', 'expected'), [
+        (set(['foo']), set(['foo']), (set(['foo']), ['foo'])),
+        (set([]), set(['foo', 'foo2']), (set(['foo', 'foo2']), [])),
+        (set(['foo']), set([]), (set([]), ['foo'])),
+    ])
+    def test_get_dirs_defferance(self, bin_diff, package_diff, expected):
+        flexmock(DirsContent).should_receive('__sub__').and_return(DirsContent(bin_diff, package_diff))
+        assert self.venv.get_dirs_differance == expected

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1,0 +1,72 @@
+import pytest
+import os
+import shutil
+import tempfile
+from flexmock import flexmock
+
+from pyp2rpm.virtualenv import *
+from pyp2rpm.name_convertor import NameConvertor
+from pyp2rpm.settings import DEFAULT_DISTRO
+
+class TestUtils(object):
+    @pytest.mark.parametrize(('input', 'expected'), [
+        (['foo', 'foo-1.0.0.dist-info'], set(['foo'])),
+        (['foo', 'foo-1.0.0.dist-info', 'foo2'], set(['foo', 'foo2'])),
+        (['foo', 'foo-1.0.0.dist-info', 'foo2-1.0.0-py2.7.egg-info'], 
+            set(['foo', 'foo2-1.0.0-py2.7.egg-info'])),
+        (['foo', 'foo2-1.0.0-py2.7.egg-info'], set(['foo', 'foo2-1.0.0-py2.7.egg-info'])),
+        ([], set()),
+    ])
+    def test_site_packages_filter(self, input, expected):
+        assert site_packages_filter(input) == expected
+
+    @pytest.mark.parametrize(('deps_list', 'package', 'expected'), [
+        ([('foo', '1.0'), ('dep1', '1.0')], 'fOO', [('dep1', '1.0')]),
+        ([('Foo', '1.0'), ('dep1', '1.0'), ('dep2', '1.0')], 'foo', 
+            [('dep1', '1.0'), ('dep2', '1.0')]),
+    ])
+    def test_deps_package_filter(self, deps_list, package, expected):
+        assert deps_package_filter(deps_list, package) == expected
+    
+    @pytest.mark.parametrize(('input', 'expected'), [
+        ([('foo', '1.0'), ('wheel', '0.24.0')], [('foo', '1.0')]),
+        ([('foo', '1.0'), ('foo2', '1.0')], [('foo', '1.0'), ('foo2', '1.0')]),
+        ([('foo', '1.0'), ('foo2', '1.0')], [('foo', '1.0'), ('foo2', '1.0')]),
+        ([], []),
+    ])
+    def test_deps_wheel_filter(self, input, expected):
+        assert deps_wheel_filter(input) == expected
+
+
+class TestDirsContent(object):
+    @pytest.mark.parametrize(('before', 'after', 'expected'), [
+        ({'activate', 'pip'}, {'activate', 'pip', 'foo'}, {'foo'}),
+        ({'activate', 'pip'}, {'activate', 'pip'}, set()),
+    ])
+    def test_sub_bin(self, before, after, expected):
+        result = DirsContent(bindir=after) - DirsContent(bindir=before)
+        assert result.bindir == expected
+     
+    @pytest.mark.parametrize(('before', 'after', 'expected'), [
+        ({'setuptools', 'pip'}, {'setuptools', 'pip', 'foo'}, {'foo'}),
+        ({'wheel', 'pip'}, {'foo', 'pip'}, {'foo'}),
+        ({'wheel', 'pip'}, {'pip'}, set()),
+    ])
+    def test_sub_sitepackages(self, before, after, expected):
+        result = DirsContent(lib_sitepackages=after) - DirsContent(lib_sitepackages=before)
+        assert result.lib_sitepackages == expected
+
+class TestVirtualEnv(object):
+    def setup_method(self, method):
+        self.temp_dir = tempfile.mkdtemp()
+        self.venv = VirtualEnv(None, self.temp_dir, NameConvertor(DEFAULT_DISTRO))
+
+    @pytest.mark.parametrize(('input', 'expected'), [
+        ([('foo', '1.0')], [['Requires', 'python-foo']]),
+        ([('foo', '1.0'), ('foo2', '1.0')], [['Requires', 'python-foo'], ['Requires', 'python-foo2']]),
+        ([], []),
+    ])
+    def test_change_deps_format(self, input, expected):
+        flexmock(NameConvertor).should_receive('rpm_name').replace_with(lambda
+                x: 'python-' + x)
+        assert self.venv.change_deps_format(input) == expected


### PR DESCRIPTION
It is possible to get more accurate metadata using this module, it installs package to virtualenv in temporary directory and scans scripts,  and site_pacakges file that appears after instalation. It can also get list of other installed packages - package runtime dependancies. Metadata from virtualenv are appended to metadata from archive and don't overwrite them.
