### PR TITLE
extract python version from setup / egg

### DIFF
--- a/pyp2rpm/bin.py
+++ b/pyp2rpm/bin.py
@@ -65,14 +65,6 @@ def main(package, v, d, r, proxy, srpm, p, b, o, t):
     PACKAGE             Provide PyPI name of the package or path to compressed source file."""
     register_file_log_handler('/tmp/pyp2rpm-{0}.log'.format(getpass.getuser()))
 
-    if not p and not b:
-        p = settings.DEFAULT_ADDITIONAL_VERSION
-    if not b:
-        b = settings.DEFAULT_PYTHON_VERSION
-    
-    p = list(p)
-    if b in p:
-        p.remove(b)
 
     if srpm:
         register_console_log_handler()

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -41,7 +41,8 @@ class Convertor(object):
         self.version = version
         self.save_dir = save_dir
         self.base_python_version = base_python_version
-        self.python_versions = python_versions
+        self.python_versions = [v for v in python_versions
+                                if not v == base_python_version]
         self.template = template
         self.name_convertor = name_convertor.NameConvertor(distro)
         if not self.template.endswith('.spec'):
@@ -73,8 +74,10 @@ class Convertor(object):
 
         self.local_file = local_file
         data = self.metadata_extractor.extract_data()
-        data.base_python_version = self.base_python_version
-        data.python_versions = self.python_versions
+        if self.base_python_version:
+            data.base_python_version = self.base_python_version
+        if self.python_versions:
+            data.python_versions = self.python_versions
         jinja_env = jinja2.Environment(loader=jinja2.ChoiceLoader([
             jinja2.FileSystemLoader(['/']),
             jinja2.PackageLoader('pyp2rpm', 'templates'), ]))

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -160,6 +160,14 @@ class LocalMetadataExtractor(object):
         return utils.license_from_trove(self.archive.get_content_of_file('EGG-INFO/PKG-INFO', True).splitlines())
 
     @property
+    def versions_from_archive(self):
+        if self.local_file.endswith('.egg'):
+            trove = self.archive.get_content_of_file('EGG-INFO/PKG-INFO', True).splitlines()
+        else:
+            trove = self.archive.find_list_argument('classifiers')
+        return utils.versions_from_trove(trove)
+
+    @property
     def has_packages(self):
         return self.archive.has_argument('packages')
 
@@ -226,6 +234,11 @@ class LocalMetadataExtractor(object):
         archive_data['license'] = self.license_from_archive
         archive_data['packages'] = self.packages
         archive_data['has_test_suite'] = self.has_test_suite
+        py_vers = self.versions_from_archive
+        archive_data['base_python_version'] = py_vers[0] if py_vers \
+                                        else settings.DEFAULT_PYTHON_VERSION
+        archive_data['python_versions'] = py_vers[1:] if py_vers \
+                                        else [settings.DEFAULT_ADDITIONAL_VERSION]
 
         return archive_data
 

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -50,6 +50,22 @@ def license_from_trove(trove):
                 license.append(settings.TROVE_LICENSES[stripped])
     return ' and '.join(license)
 
+def versions_from_trove(trove):
+    """Finds out python version from list of trove classifiers.
+    Args:
+        trove: list of trove classifiers
+    Returns:
+        python version string
+    """
+    versions = set()
+    for classifier in trove:
+        if 'Programming Language :: Python ::' in classifier:
+            ver = classifier.split('::')[-1]
+            major = ver.split('.')[0].strip()
+            if major:
+                versions.add(major)
+    return sorted(versions)
+
 
 def build_srpm(specfile, save_dir):
     """Builds a srpm from given specfile using rpmbuild.

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -87,6 +87,20 @@ class TestMetadataExtractor(object):
         with self.e[i].archive:
             assert self.e[i].sphinx_dir == expected
 
+    @pytest.mark.parametrize(('i', 'expected'), [
+        (0, ['2', ['3']]),
+        (1, ['3', []]),
+        (2, ['2', ['3']]),
+        (3, ['2', ['3']]),
+        (5, ['2', ['3']]),
+        (6, ['2', ['3']]),
+    ])
+    def test_extract_versions(self, i, expected):
+        with self.e[i].archive:
+            pkgdata = self.e[i].extract_data()
+            assert [pkgdata.data['base_python_version'],
+                    pkgdata.data['python_versions']] == expected
+
 class TestPypiMetadataExtractor(object):
     td_dir = '{0}/test_data/'.format(tests_dir)
     client = flexmock(


### PR DESCRIPTION
Some packages specifies python 3 in their setup.py / egg and can't be built on python 2.
This patch extracts proper python version from package classifiers.
