### PR TITLE
Epel template

### DIFF
--- a/pyp2rpm/bin.py
+++ b/pyp2rpm/bin.py
@@ -126,10 +126,7 @@ def main(package, v, d, s, r, proxy, srpm, p, b, o, t, venv):
 
         if srpm:
             msg = utils.build_srpm(spec_path, d)
-            if utils.PY3:
-                logger.info(msg.decode('utf-8'))
-            else:
-                logger.info(msg)
+            logger.info(msg)
 
     else:
         logger.debug('Printing specfile to stdout.')

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -61,6 +61,29 @@ class Convertor(object):
                 and not os.path.isdir(self.package):
             self.pypi = False
 
+    def merge_versions(self, data):
+        """Merges python versions specified in command lines options with
+        extracted versions, checks if some of the versions is not > 2 if EPEL6 template
+        will be used.
+        """
+        if self.template == "epel6.spec":
+            # if user requested version greater than 2, writes error message and exits
+            if (any(int(ver[0]) > 2 for ver in self.python_versions
+                    + ([self.base_python_version] if self.base_python_version else [])
+                    + [data.base_python_version])):
+                sys.stderr.write("Invalid version, major number of python version for EPEL6 "
+                                 "spec file must not be greater than 2.\n".format(self.base_python_version))
+                sys.exit(1)
+            # if version greater than 2 were extracted it is removed
+            data.python_versions = [ver for ver in data.python_versions if not int(ver[0]) > 2]
+
+        if self.base_python_version or self.python_versions:
+            data.base_python_version = self.base_python_version
+            data.python_versions = [v for v in self.python_versions
+                                    if not v == data.base_python_version]
+        elif data.base_python_version in data.python_versions:
+            data.python_versions.remove(data.base_python_version)
+
     def convert(self):
         """Returns RPM SPECFILE.
         Returns:
@@ -83,13 +106,7 @@ class Convertor(object):
         data = self.metadata_extractor.extract_data(self.client)
         logger.debug('Extracted metadata:')
         logger.debug(pprint.pformat(data.data))
-
-        if self.base_python_version or self.python_versions:
-            data.base_python_version = self.base_python_version
-            data.python_versions = [v for v in self.python_versions
-                                    if not v == data.base_python_version]
-        elif data.base_python_version in data.python_versions:
-            data.python_versions.remove(data.base_python_version)
+        self.merge_versions(data)
 
         jinja_env = jinja2.Environment(loader=jinja2.ChoiceLoader([
             jinja2.FileSystemLoader(['/']),

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -64,7 +64,9 @@ class Convertor(object):
     def merge_versions(self, data):
         """Merges python versions specified in command lines options with
         extracted versions, checks if some of the versions is not > 2 if EPEL6 template
-        will be used.
+        will be used. attributes base_python_version and python_versions contain
+        values specified by command line options or default values, 
+        data.base_python_version and data.python_versions contain extracted data.
         """
         if self.template == "epel6.spec":
             # if user requested version greater than 2, writes error message and exits

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -2,8 +2,8 @@ from pyp2rpm import settings
 from pyp2rpm import name_convertor
 
 
-def name_for_python_version(name, version, default_number=False):
-    return name_convertor.NameConvertor.rpm_versioned_name(name, version, default_number)
+def name_for_python_version(name, version, default_number=False, epel=False):
+    return name_convertor.NameConvertor.rpm_versioned_name(name, version, default_number, epel)
 
 
 def script_name_for_python_version(name, version, minor=False, default_number=True):

--- a/pyp2rpm/name_convertor.py
+++ b/pyp2rpm/name_convertor.py
@@ -21,7 +21,7 @@ class NameConvertor(object):
         self.reg_end = re.compile(r'(.*)-(python)(\d*|)$')
 
     @staticmethod
-    def rpm_versioned_name(name, version, default_number=False):
+    def rpm_versioned_name(name, version, default_number=False, epel=False):
         """Properly versions the name.
         For example:
         rpm_versioned_name('python-foo', '26') will return python26-foo
@@ -41,7 +41,8 @@ class NameConvertor(object):
             found = regexp.search(name)
             # second check is to avoid renaming of python2-devel to python-devel
             if found and found.group(2) != 'devel':
-                return 'python-{0}'.format(regexp.search(name).group(2))
+                if not epel:
+                    return 'python-{0}'.format(regexp.search(name).group(2))
             return name
 
         versioned_name = name
@@ -51,7 +52,9 @@ class NameConvertor(object):
                 versioned_name = re.sub(r'^python(\d*|)-', 'python{0}-'.format(version), name)
             else:
                 versioned_name = 'python{0}-{1}'.format(version, name)
-
+            if epel and version != settings.DEFAULT_PYTHON_VERSION:
+                versioned_name = versioned_name.replace('{0}'.format(
+                    version), '%{{python{0}_pkgversion}}'.format(version))
         return versioned_name
 
     def rpm_name(self, name, python_version=settings.DEFAULT_PYTHON_VERSION):

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -1,0 +1,142 @@
+{{ data.credit_line }}
+{% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
+%global pypi_name {{ data.name }}
+{%- for pv in data.python_versions %}
+%global with_python{{ pv }} 1
+{%- endfor %}
+
+Name:           {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(data.base_python_version) }}
+Version:        {{ data.version }}
+Release:        1%{?dist}
+Summary:        {{ data.summary }}
+
+License:        {{ data.license }}
+URL:            {{ data.home_page }}
+Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+
+{%- if not data.has_extension %}
+BuildArch:      noarch
+{%- endif %}
+{{ dependencies(data.build_deps, False, data.base_python_version, data.base_python_version) }}
+{%- for pv in data.python_versions %}
+{{ dependencies(data.build_deps, False, pv, data.base_python_version) }}
+{%- endfor %}
+{{ dependencies(data.runtime_deps, True, data.base_python_version, data.base_python_version) }}
+
+%description
+{{ data.description|truncate(400)|wordwrap }}
+{% call(pv) for_python_versions(data.python_versions) -%}
+%package -n     {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+Summary:        {{ data.summary }}
+{{ dependencies(data.runtime_deps, True, pv, pv) }}
+
+%description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+{{ data.description|truncate(400)|wordwrap }}
+{%- endcall %}
+
+%prep
+%setup -q -n %{pypi_name}-%{version}
+{%- if data.has_bundled_egg_info %}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+{%- endif %}
+{% call(pv) for_python_versions([data.base_python_version] + data.python_versions,
+data.base_python_version) -%}
+{%- if pv != data.base_python_version -%}
+rm -rf python{{pv}}
+cp -a . python{{pv}}
+find python{{pv}} -name '*.py' | xargs sed -i '1s|^#!python|#!%{__python{{pv}}}|'
+{%- endif %}
+{%- if data.sphinx_dir %}
+# generate html docs {# TODO: generate properly for other versions (pushd/popd into their dirs...)
+# #}
+sphinx-build{% if pv != data.base_python_version %}-{{ pv }}{% endif %} {{ data.sphinx_dir }} html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+{%- endif %}
+{%- endcall %}
+
+%build
+{%- call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+{%- if pv != data.base_python_version -%}
+pushd python{{ pv }}
+{%- endif %}
+{% if data.has_extension %}CFLAGS="$RPM_OPT_FLAGS" {% endif %}{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py build
+{% if pv != data.base_python_version -%}
+popd
+{%- endif %}
+{%- endcall %}
+
+%install
+{%- if data.python_versions|length > 0 %}
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install (and we want the python2 version
+# to be the default for now).
+{%- endif -%}
+{%- call(pv) for_python_versions(data.python_versions + [data.base_python_version], data.base_python_version) -%}
+{%- if pv != data.base_python_version -%}
+pushd python{{ pv }}
+{%- endif %}
+{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py install --skip-build --root %{buildroot}
+{%- if pv != data.base_python_version %}
+{%- if data.scripts %}
+{%- for script in data.scripts %}
+mv %{buildroot}%{_bindir}/{{ script }} %{buildroot}/%{_bindir}/{{ script|script_name_for_python_version(pv) }}
+{%- endfor %}
+{%- endif %}
+popd
+{%- endif %}
+{%- endcall %}
+
+{%- if data.has_test_suite %}
+%check
+{%- call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+{%- if pv != data.base_python_version -%}
+pushd python{{ pv }}
+{%- endif %}
+{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py test
+{% if pv != data.base_python_version -%}
+popd
+{%- endif %}
+{%- endcall %}
+{%- endif %}
+
+{% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
+%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
+%doc {% if data.sphinx_dir %}html {% endif %}{{ data.doc_files|join(' ') }}
+{%- if data.scripts %}
+{%- for script in data.scripts %}
+%{_bindir}/{{ script|script_name_for_python_version(pv, minor=False, default_number=False) }}
+{%- endfor %}
+{%- endif %}
+{%- if data.py_modules %}
+{% for module in data.py_modules -%}
+{%- if pv == '3' -%}
+%dir {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/*
+{%- endif %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(module) }}.py{% if pv != '3'%}*{% endif %}
+{%- endfor %}
+{%- endif %}
+{%- if data.has_extension %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(data.underscored_name) }}
+{%- if data.has_pth %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+{%- endif %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+{%- else %}
+{%- if data.has_packages %}
+{%- for package in data.packages %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.underscored_name) }}
+{%- endfor %}
+{%- endif %}
+{%- if data.has_pth %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+{%- endif %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+{%- endif %}
+{% endcall %}
+
+%changelog
+* {{ data.changelog_date_packager }} - {{ data.version }}-1
+- Initial package.

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -1,0 +1,120 @@
+{{ data.credit_line }}
+{% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
+%global pypi_name {{ data.name }}
+
+Name:           {{ data.pkg_name|macroed_pkg_name(data.name) }}
+Version:        {{ data.version }}
+Release:        1%{?dist}
+Summary:        {{ data.summary }}
+
+License:        {{ data.license }}
+URL:            {{ data.home_page }}
+Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+
+{%- if not data.has_extension %}
+BuildArch:      noarch
+{%- endif %}
+{{ dependencies(data.build_deps, False, data.base_python_version, data.base_python_version,
+use_with=True, epel=True) }}
+{%- for pv in data.python_versions %}
+{{ dependencies(data.build_deps, False, pv, data.base_python_version,
+use_with=False, epel=True) }}
+{%- endfor %}
+
+%description
+{{ data.description|truncate(400)|wordwrap }}
+{% for pv in ([data.base_python_version] + data.python_versions) %}
+%package -n     {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True, True)}}
+Summary:        {{ data.summary }}
+{{ dependencies(data.runtime_deps, True, pv, pv, use_with=False, epel=True) }}
+%description -n {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True, True)}}
+{{ data.description|truncate(400)|wordwrap }}
+{% endfor -%}
+{%- if data.sphinx_dir %}
+%package -n python-%{pypi_name}-doc
+Summary:        {{ data.name }} documentation
+%description -n python-%{pypi_name}-doc
+Documentation for {{ data.name }}
+{%- endif %}
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+{%- if data.has_bundled_egg_info %}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+{%- endif %}
+
+%build
+{%- for pv in [data.base_python_version] + data.python_versions %}
+{% if data.has_extension %}CFLAGS="$RPM_OPT_FLAGS" {% endif %}{{'%{__python2}'|python_bin_for_python_version(pv) }} setup.py build
+{%- endfor %}
+{%- if data.sphinx_dir %}
+# generate html docs 
+{{ "sphinx-build"|script_name_for_python_version(data.base_python_version, False, False) }} {{ data.sphinx_dir }} html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+{%- endif %}
+
+%install
+{%- if data.python_versions|length > 0 %}
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install.
+{%- endif %}
+{%- for pv in data.python_versions + [data.base_python_version] %}
+{{ '%{__python2}'|python_bin_for_python_version(pv) }} setup.py install --skip-build --root %{buildroot}
+{% for script in data.scripts -%}
+cp %{buildroot}/%{_bindir}/{{ script }} %{buildroot}/%{_bindir}/{{ script|script_name_for_python_version(pv) }}
+ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%{_bindir}/{{ script|script_name_for_python_version(pv, True) }}
+{% endfor %}
+{%- endfor -%}
+{% if data.has_test_suite %}
+
+%check
+{%- for pv in [data.base_python_version] + data.python_versions %}
+%{__python{{ pv }}} setup.py test
+{%- endfor %}
+{%- endif %}
+{% for pv in [data.base_python_version] + data.python_versions %}
+%files -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True, True) }} 
+%doc {{data.doc_files|join(' ') }}
+{%- for script in data.scripts %}
+{%- if pv == data.base_python_version %}
+%{_bindir}/{{ script }}
+{%- endif %}
+%{_bindir}/{{ script|script_name_for_python_version(pv) }}
+%{_bindir}/{{ script|script_name_for_python_version(pv, True) }}
+{%- endfor %}
+{%- if data.py_modules %}
+{% for module in data.py_modules -%}
+{%- if pv == '3' -%}
+%dir {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/*
+{%- endif %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(module) }}.py{% if pv != '3'%}*{% endif %}
+{%- endfor %}
+{%- endif %}
+{%- if data.has_extension %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(data.underscored_name) }}
+{%- if data.has_pth %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+{%- endif %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+{%- else %}
+{%- if data.has_packages %}
+{%- for package in data.packages %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.underscored_name) }}
+{%- endfor %}
+{%- endif %}
+{%- if data.has_pth %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+{%- endif %}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+{%- endif %}
+{% endfor %}
+{%- if data.sphinx_dir %}
+%files -n python-%{pypi_name}-doc
+%doc html 
+{% endif %}
+%changelog
+* {{ data.changelog_date_packager }} - {{ data.version }}-1
+- Initial package.

--- a/pyp2rpm/templates/macros.spec
+++ b/pyp2rpm/templates/macros.spec
@@ -1,6 +1,7 @@
 {# prints a single dependency for a specific python version #}
-{%- macro one_dep(dep, python_version) %}
-{{ dep[0] }}:{{ ' ' * (15 - dep[0]|length) }}{{ dep[1]|name_for_python_version(python_version) }}{% if dep[2] is defined %} {{ dep[2] }} {{ dep[3] }}{% endif %}
+{%- macro one_dep(dep, python_version, epel=False) %}
+{{ dep[0] }}:{{ ' ' * (15 - dep[0]|length) }}{{ dep[1]|name_for_python_version(python_version,
+False, epel) }}{% if dep[2] is defined %} {{ dep[2] }} {{ dep[3] }}{% endif %}
 {%- endmacro %}
 
 {# Prints given deps (runtime or buildtime for given python_version,
@@ -8,14 +9,14 @@
 {# This cannot be implemented by macro for_python_versions because it needs to
    decide on its own, whether to even use the %if 0%{?with_pythonX} or not. #}
 {%- macro dependencies(deps, runtime, python_version, base_python_version,
-use_with=True) %}
+use_with=True, epel=False) %}
 {%- if deps|length > 0 or not runtime %} {# for build deps, we always have at least 1 - pythonXX-devel #}
 {%- if python_version != base_python_version and use_with %}
-%if %{?with_python{{ python_version }}}
+%if 0%{?with_python{{ python_version }}}
 {%- endif %}
 {%- for dep in deps -%}
 {%- if python_version == base_python_version or not dep[1] == 'python-sphinx' -%}
-{{ one_dep(dep, python_version) }}
+{{ one_dep(dep, python_version, epel) }}
 {%- endif -%}
 {%- endfor %}
 {%- if python_version != base_python_version and use_with %}

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
     setup_requires=['setuptools',
                     'flexmock >= 0.9.3',
                     'pytest-runner',
+                    'click',
+                    'Jinja2',
                     ],
     tests_require=['pytest'],
     extras_require = {

--- a/tests/test_data/python-Jinja2.spec
+++ b/tests/test_data/python-Jinja2.spec
@@ -1,0 +1,100 @@
+# Created by pyp2rpm-3.1.2
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python-setuptools
+BuildRequires:  python2-devel
+BuildRequires:  python-sphinx
+ 
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-devel
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n     python2-%{pypi_name}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+%{?python_provide:%python_provide python2-%{pypi_name}}
+ 
+Requires:       python-MarkupSafe
+Requires:       python-setuptools
+%description -n python2-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n     python3-%{pypi_name}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+%{?python_provide:%python_provide python3-%{pypi_name}}
+ 
+Requires:       python3-MarkupSafe
+Requires:       python3-setuptools
+%description -n python3-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%py3_build
+# generate html docs 
+sphinx-build docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install.
+%py3_install
+
+%py2_install
+
+
+%files -n python2-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python3-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html 
+
+%changelog
+* Tue Aug 09 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/python-Jinja2_base.spec
+++ b/tests/test_data/python-Jinja2_base.spec
@@ -1,0 +1,72 @@
+# Created by pyp2rpm-3.1.2
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-devel
+BuildRequires:  python3-sphinx
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n     python3-%{pypi_name}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+%{?python_provide:%python_provide python3-%{pypi_name}}
+ 
+Requires:       python3-MarkupSafe
+Requires:       python3-setuptools
+%description -n python3-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py3_build
+# generate html docs 
+sphinx-build-3 docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+%py3_install
+
+
+%files -n python3-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html 
+
+%changelog
+* Tue Aug 09 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/python-Jinja2_epel6.spec
+++ b/tests/test_data/python-Jinja2_epel6.spec
@@ -1,0 +1,55 @@
+# Created by pyp2rpm-3.1.2
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python-setuptools
+BuildRequires:  python2-devel
+BuildRequires:  python-sphinx
+ 
+Requires:       python-MarkupSafe
+Requires:       python-setuptools
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+
+%prep
+%setup -q -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+# generate html docs 
+sphinx-build docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%build
+%{__python2} setup.py build
+
+
+%install
+%{__python2} setup.py install --skip-build --root %{buildroot}
+
+%files
+%doc html README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+
+%changelog
+* Tue Aug 09 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/python-Jinja2_epel7.spec
+++ b/tests/test_data/python-Jinja2_epel7.spec
@@ -1,0 +1,96 @@
+# Created by pyp2rpm-3.1.2
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python-setuptools
+BuildRequires:  python2-devel
+BuildRequires:  python-sphinx
+ 
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-devel
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n     python2-%{pypi_name}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+ 
+Requires:       python-MarkupSafe
+Requires:       python-setuptools
+%description -n python2-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n     python%{python3_pkgversion}-%{pypi_name}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+ 
+Requires:       python%{python3_pkgversion}-MarkupSafe
+Requires:       python%{python3_pkgversion}-setuptools
+%description -n python%{python3_pkgversion}-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired nonXML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li> {% ...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%{__python2} setup.py build
+%{__python3} setup.py build
+# generate html docs 
+sphinx-build docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install.
+%{__python3} setup.py install --skip-build --root %{buildroot}
+
+%{__python2} setup.py install --skip-build --root %{buildroot}
+
+
+%files -n python2-%{pypi_name} 
+%doc README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python%{python3_pkgversion}-%{pypi_name} 
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html 
+
+%changelog
+* Tue Aug 09 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,42 @@
+import pytest
+import os
+from scripttest import TestFileEnvironment
+
+from pyp2rpm.bin import main
+
+tests_dir = os.path.split(os.path.abspath(__file__))[0]
+
+
+class TestSpec(object):
+    td_dir = '{0}/test_data/'.format(tests_dir)
+    bin_dir = os.path.split(tests_dir)[0] + '/'
+    exe = 'python {0}mybin.py'.format(bin_dir)
+
+    def setup_method(self, method):
+        self.env = TestFileEnvironment('{0}/test_output/'.format(tests_dir))
+
+    @pytest.mark.parametrize(('package', 'options', 'expected'), [
+        ('Jinja2', '', 'python-Jinja2.spec'),
+        ('Jinja2', '-b3', 'python-Jinja2_base.spec'),
+        ('Jinja2', '-t epel7', 'python-Jinja2_epel7.spec'),
+        ('Jinja2', '-t epel6', 'python-Jinja2_epel6.spec'),
+    ])
+    def test_spec(self, package, options, expected):
+        with open(self.td_dir + expected) as fi:
+            self.spec_content = fi.read()
+        res = self.env.run('{0} {1} {2}'.format(self.exe, package, options))
+        # changelog have to be cut from spec files
+        assert ''.join(res.stdout.split('\n')[1:-4]) == ''.join(self.spec_content.split('\n')[1:-4])
+
+
+class TestSrpm(object):
+    td_dir = '{0}/test_data/'.format(tests_dir)
+    bin_dir = os.path.split(tests_dir)[0] + '/'
+    exe = 'python {0}mybin.py'.format(bin_dir)
+
+    def setup_method(self, method):
+        self.env = TestFileEnvironment('{0}/test_output/'.format(tests_dir))
+
+    def test_srpm(self):
+        res = self.env.run('{0} Jinja2 --srpm'.format(self.exe), expect_stderr=True)
+        assert res.returncode == 0

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,14 @@ envlist = py26, py27, py34, py35
 [testenv]
 deps = 
     setuptools 
+    Jinja2
     flexmock
     virtualenv-api
     virtualenv
+    scripttest
+    click
 
-commands = python setup.py test --addopts -v
+commands = python setup.py test --addopts -vv
 
 [testenv :py26]
 basepython=python2.6


### PR DESCRIPTION
Prototype of EPEL template, fixes #25:
- doesn't use modern macros (%py2_install %py2_build)
- forbids base version > 2 if template is used
- disables with_pythonX macro for versions > 2
