### PR TITLE
License files

### DIFF
--- a/pyp2rpm/bin.py
+++ b/pyp2rpm/bin.py
@@ -103,7 +103,8 @@ def main(package, v, d, s, r, proxy, srpm, p, b, o, t, venv):
         if r:
             spec_name = r + '.spec'
         else:
-            spec_name = 'python-' + convertor.name + '.spec'
+            prefix = 'python-' if not convertor.name.startswith('python-') else ''
+            spec_name = prefix + convertor.name + '.spec'
         logger.info('Using name: {0} for specfile.'.format(spec_name))
         if d == settings.DEFAULT_PKG_SAVE_PATH:
             # default save_path is rpmbuild tree so we want to save spec

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -354,8 +354,9 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
             else settings.DEFAULT_PYTHON_VERSION
         archive_data['python_versions'] = py_vers[1:] if py_vers \
             else [settings.DEFAULT_ADDITIONAL_VERSION]
-
-        archive_data['doc_files'] = self.doc_files
+        doc_files = self.doc_files
+        archive_data['doc_files'] = [doc for doc in doc_files if 'license' not in doc.lower()]
+        archive_data['doc_license'] = [doc for doc in doc_files if 'license' in doc.lower()]
         archive_data['py_modules'] = self.py_modules
         archive_data['has_test_suite'] = self.has_test_suite
         archive_data['has_bundled_egg_info'] = self.has_bundled_egg_info
@@ -548,7 +549,9 @@ class WheelMetadataExtractor(LocalMetadataExtractor):
         archive_data['license'] = self.license
         archive_data['summary'] = self.summary
         archive_data['home_page'] = self.home_page
-        archive_data['doc_files'] = self.doc_files
+        doc_files = self.doc_files
+        archive_data['doc_files'] = [doc for doc in doc_files if 'license' not in doc.lower()]
+        archive_data['doc_license'] = [doc for doc in doc_files if 'license' in doc.lower()]
         archive_data['has_pth'] = self.has_pth
         archive_data['runtime_deps'] = utils.unique_deps(self.runtime_deps)
         archive_data['build_deps'] = utils.unique_deps([['BuildRequires', 'python2-devel'],

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -159,6 +159,14 @@ class LocalMetadataExtractor(object):
 
         return data
 
+    @staticmethod
+    def separate_license_files(doc_files):
+        other = [doc for doc in doc_files if all(s not in doc.lower() for s in
+                                                 settings.LICENSE_FILES)]
+        licenses = [doc for doc in doc_files if any(s in doc.lower() for s in
+                                                    settings.LICENSE_FILES)]
+        return other, licenses
+
     @property
     @abstractmethod
     def data_from_archive(self):
@@ -354,9 +362,9 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
             else settings.DEFAULT_PYTHON_VERSION
         archive_data['python_versions'] = py_vers[1:] if py_vers \
             else [settings.DEFAULT_ADDITIONAL_VERSION]
-        doc_files = self.doc_files
-        archive_data['doc_files'] = [doc for doc in doc_files if 'license' not in doc.lower()]
-        archive_data['doc_license'] = [doc for doc in doc_files if 'license' in doc.lower()]
+
+        (archive_data['doc_files'],
+         archive_data['doc_license']) = self.separate_license_files(self.doc_files)
         archive_data['py_modules'] = self.py_modules
         archive_data['has_test_suite'] = self.has_test_suite
         archive_data['has_bundled_egg_info'] = self.has_bundled_egg_info
@@ -549,9 +557,8 @@ class WheelMetadataExtractor(LocalMetadataExtractor):
         archive_data['license'] = self.license
         archive_data['summary'] = self.summary
         archive_data['home_page'] = self.home_page
-        doc_files = self.doc_files
-        archive_data['doc_files'] = [doc for doc in doc_files if 'license' not in doc.lower()]
-        archive_data['doc_license'] = [doc for doc in doc_files if 'license' in doc.lower()]
+        (archive_data['doc_files'],
+         archive_data['doc_license']) = self.separate_license_files(self.doc_files)
         archive_data['has_pth'] = self.has_pth
         archive_data['runtime_deps'] = utils.unique_deps(self.runtime_deps)
         archive_data['build_deps'] = utils.unique_deps([['BuildRequires', 'python2-devel'],

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -12,6 +12,7 @@ ARCHIVE_SUFFIXES = ['.tar', '.tgz', '.tar.gz', '.tar.bz2',
                     '.gz', '.bz2', '.xz', '.zip', '.egg', '.whl']
 EXTENSION_SUFFIXES = ['.c', '.cpp']
 DOC_FILES_RE = [r'readme.+', r'licens.+', r'copying.+']
+LICENSE_FILES = ['license', 'copyright', 'copying']
 SPHINX_DIR_RE = r'[^/]+/doc.?'
 PYPI_URL = 'https://pypi.python.org/pypi'
 PYPI_USABLE_DATA = ['description', 'summary', 'license', 'home_page', 'requires']

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -75,6 +75,9 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endif %}
 {% for pv in [data.base_python_version] + data.python_versions %}
 %files -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }} 
+{%- if data.doc_license %}
+%license {{data.doc_license|join(' ')}}
+{%- endif %}
 %doc {{data.doc_files|join(' ') }}
 {%- for script in data.scripts %}
 {%- if pv == data.base_python_version %}

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -121,7 +121,7 @@ class TestPyPIMetadataExtension(object):
     td_dir = '{0}/test_data/'.format(tests_dir)
     client = flexmock(
         release_urls=lambda n, v: [{'md5_digest': '9a7a2f6943baba054cf1c28e05a9198e',
-                                    'url': 'http://pypi.python.org/packages/source/r/restsh/restsh-0.1.tar.gz'}],
+                                    'url': 'https://files.pythonhosted.org/packages/source/r/restsh/restsh-0.1.tar.gz'}],
         release_data=lambda n, v: {'description': 'UNKNOWN',
                                    'release_url': 'http://pypi.python.org/pypi/restsh/0.1',
                                    'classifiers': ['Development Status :: 4 - Beta',
@@ -143,7 +143,7 @@ class TestPyPIMetadataExtension(object):
     @pytest.mark.parametrize(('what', 'expected'), [
         ('description', 'UNKNOWN'),
         ('md5', '9a7a2f6943baba054cf1c28e05a9198e'),
-        ('url', 'http://pypi.python.org/packages/source/r/restsh/restsh-0.1.tar.gz'),
+        ('url', 'https://files.pythonhosted.org/packages/source/r/restsh/restsh-0.1.tar.gz'),
         ('license', 'BSD'),
         ('summary', 'A simple rest shell client')
     ])

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -117,7 +117,7 @@ class TestMetadataExtractor(object):
                     pkgdata.data['python_versions']] == expected
 
 
-class TestSetupPyMetadataExtractor(object):
+class TestPyPIMetadataExtension(object):
     td_dir = '{0}/test_data/'.format(tests_dir)
     client = flexmock(
         release_urls=lambda n, v: [{'md5_digest': '9a7a2f6943baba054cf1c28e05a9198e',
@@ -171,6 +171,23 @@ class TestSetupPyMetadataExtractor(object):
     def test_extract(self, i, what, expected):
         data = self.e[i].extract_data()
         assert getattr(data, what) == expected
+
+    @pytest.mark.parametrize(('doc_files', 'license', 'other'), [
+        (['LICENSE', 'README'], ['LICENSE'], ['README']),
+        ([], [], []),
+        (['README', 'DESCRIPTION'], [], ['README', 'DESCRIPTION']),
+        (['LICENSE', './dir/LICENSE', 'README'], ['LICENSE', './dir/LICENSE'], ['README']),
+        (['LICENSE.MIT', './LICENSE.CC-BY-SA-3.0'],
+         ['LICENSE.MIT', './LICENSE.CC-BY-SA-3.0'], []),
+        (['README', 'COPYRIGHT'], ['COPYRIGHT'], ['README']),
+        (['COPYRIGHT.txt'], ['COPYRIGHT.txt'], []),
+        (['README', 'COPYING'], ['COPYING'], ['README']),
+    ])
+    def test_doc_files(self, doc_files, license, other):
+        flexmock(me.SetupPyMetadataExtractor).should_receive('doc_files').and_return(doc_files)
+        data = self.e[0].data_from_archive
+        assert data['doc_license'] == license
+        assert data['doc_files'] == other
 
 
 class TestWheelMetadataExtractor(object):

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -182,7 +182,7 @@ class TestWheelMetadataExtractor(object):
             self.td_dir), 'setuptools', self.nc, '19.6.2'))
 
     @pytest.mark.parametrize(('what', 'expected'), [
-        ('doc_files', set(['DESCRIPTION.rst'])),
+        ('doc_files', ['DESCRIPTION.rst']),
         ('has_test_suite', True),
         ('py_modules', set(['_markerlib', 'pkg_resources', 'setuptools'])),
         ('runtime_deps', [['Requires', 'python-certifi', '==', '2015.11.20']])
@@ -198,12 +198,13 @@ class TestDistMetadataExtractor(object):
     def setup_method(self, method):
         self.nc = NameConvertor('fedora')
         self.e = [me.DistMetadataExtractor('{0}plumbum-0.9.0.tar.gz'.format(
-                      self.td_dir), 'plumbum', self.nc, '0.9.0'),
-                  me.DistMetadataExtractor('{0}coverage_pth-0.0.1.tar.gz'.format(
-                      self.td_dir), 'coverage_pth', self.nc, '0.0.1')]
+            self.td_dir), 'plumbum', self.nc, '0.9.0'),
+            me.DistMetadataExtractor('{0}coverage_pth-0.0.1.tar.gz'.format(
+                self.td_dir), 'coverage_pth', self.nc, '0.0.1')]
 
     @pytest.mark.parametrize(('i', 'what', 'expected'), [
-        (0, 'doc_files', ['README.rst', 'LICENSE']),
+        (0, 'doc_files', ['README.rst']),
+        (0, 'doc_license', ['LICENSE']),
         (0, 'has_test_suite', False),
         (0, 'license', 'MIT'),
         (0, 'build_cmd', '%{py2_build}'),


### PR DESCRIPTION
Doc files are separated to license files and other doc files, License files are listed in %license section of the spec file instead of %doc.
This PR also contains minor fix of created spec file's name when -s/--srpm option is set.
