### PR TITLE
Tests: Run mybin.py using 'python' and not the shebang

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,7 @@ tests_dir = os.path.split(os.path.abspath(__file__))[0]
 class TestSpec(object):
     td_dir = '{0}/test_data/'.format(tests_dir)
     bin_dir = os.path.split(tests_dir)[0] + '/'
+    exe = 'python {0}mybin.py'.format(bin_dir)
 
     def setup_method(self, method):
         self.env = TestFileEnvironment('{0}/test_output/'.format(tests_dir))
@@ -23,7 +24,7 @@ class TestSpec(object):
     def test_spec(self, package, options, expected):
         with open(self.td_dir + expected) as fi:
             self.spec_content = fi.read()
-        res = self.env.run('{0}mybin.py {1} {2}'.format(self.bin_dir, package, options))
+        res = self.env.run('{0} {1} {2}'.format(self.exe, package, options))
         # changelog have to be cut from spec files
         assert res.stdout[:-82] == self.spec_content[:-82]
 
@@ -36,5 +37,5 @@ class TestSrpm(object):
         self.env = TestFileEnvironment('{0}/test_output/'.format(tests_dir))
 
     def test_srpm(self):
-        res = self.env.run('{0}mybin.py Jinja2 --srpm'.format(self.bin_dir), expect_stderr=True)
+        res = self.env.run('{0} Jinja2 --srpm'.format(self.exe), expect_stderr=True)
         assert res.returncode == 0


### PR DESCRIPTION
Otherwise /usr/bin/python3 is used and not the one from virtualenv/tox

Fixes travis-ci/travis-ci#6168
