### PR TITLE
Drop Python 2.6 support and remove py26 from tox envlist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-- '2.6'
 - '2.7'
 - '3.4'
 - '3.5'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Upcoming
+* Drop Python 2.6 support 
+
 3.2.1
 * Update MANIFEST.in
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py34, py35
+envlist = py27, py34, py35
 
 [testenv]
 deps = 
@@ -17,6 +17,3 @@ deps =
     click
 
 commands = python setup.py test --addopts -vv
-
-[testenv :py26]
-basepython=python2.6


### PR DESCRIPTION
Running tests with tox has a dependency on `virtualenv-api` which stopped supporting Python 2.6 a long time ago ([commit](https://github.com/sjkingo/virtualenv-api/commit/e2aaad332d383b1673159dedb666bd70d487701b)) . With the changes in the latest `virtualenv-api` release 2.1.13, `pyp2rpm`'s tests started to reflect this and running tests in py26 tox environment started to fail. Continuing to support Python 2.6 officially without being able to run test in py26 makes no sense. Unless we want to introduce dependency on a specific `virtualenv-api` version as [here](https://github.com/fedora-python/pyp2rpm/pull/89/commits/5b28f392524f1280b97455ea6a218ada232df201).