### PR TITLE
 Fix "File not found" errors

### DIFF
--- a/mybin.py
+++ b/mybin.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 from pyp2rpm.bin import main
 
 main()

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -59,7 +59,7 @@ def package_to_path(package, module):
     if package == module:
         return "%{pypi_name}"
     else:
-        return package.replace('-', '_')
+        return package
 
 __all__ = [name_for_python_version,
            script_name_for_python_version,

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -135,7 +135,10 @@ class LocalMetadataExtractor(object):
     @property
     def has_pth(self):
         """Figure out if package has pth file """
-        return "." in self.name
+        if virtualenv is None:
+            return "." in self.name
+        else:
+            return None
 
     @property
     def has_extension(self):

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -85,7 +85,7 @@ def venv_metadata_extension(extraction_fce):
 
 
 def process_description(description_fce):
-    """Removes special character delimiters, titles 
+    """Removes special character delimiters, titles
     and wraps paragraphs.
     """
     def inner(description):
@@ -165,8 +165,10 @@ class LocalMetadataExtractor(object):
             setattr(data, "scripts", utils.remove_major_minor_suffix(data.data['scripts']))
         # for example nose has attribute `packages` but instead of name listing the pacakges
         # is using function to find them, that makes data.packages an empty set
-        if getattr(data, "packages") == set():
+        # if virtualenv is disabled
+        if virtualenv is None and getattr(data, "packages") == set():
             data.packages = set([data.name])
+
 
         return data
 

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -11,6 +11,7 @@ KNOWN_DISTROS = ['fedora', 'mageia', 'pld']
 ARCHIVE_SUFFIXES = ['.tar', '.tgz', '.tar.gz', '.tar.bz2',
                     '.gz', '.bz2', '.xz', '.zip', '.egg', '.whl']
 EXTENSION_SUFFIXES = ['.c', '.cpp']
+MODULE_SUFFIXES = ('.py', '.pyc')
 DOC_FILES_RE = [r'readme.+', r'licens.+', r'copying.+']
 LICENSE_FILES = ['license', 'copyright', 'copying']
 SPHINX_DIR_RE = r'[^/]+/doc.?'

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -111,7 +111,7 @@ popd
 {%- endif %}
 {%- if data.py_modules %}
 {% for module in data.py_modules -%}
-{%- if pv == '3' -%}
+{%- if pv == '3' %}
 %dir {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/
 {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/*
 {%- endif %}

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -119,7 +119,11 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_extension %}
-{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(data.underscored_name) }}
+{%- if data.has_packages %}
+{%- for package in data.packages %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
+{%- endfor %}
+{%- endif %}
 {%- if data.has_pth %}
 {{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
 {%- endif %}
@@ -127,7 +131,7 @@ popd
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
-{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.underscored_name) }}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -94,7 +94,11 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endfor %}
 {%- endif %}
 {%- if data.has_extension %}
-{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(data.underscored_name) }}
+{%- if data.has_packages %}
+{%- for package in data.packages %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
+{%- endfor %}
+{%- endif %}
 {%- if data.has_pth %}
 {{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
 {%- endif %}
@@ -102,7 +106,7 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
-{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.underscored_name) }}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -88,7 +88,7 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endfor %}
 {%- if data.py_modules %}
 {% for module in data.py_modules -%}
-{%- if pv == '3' -%}
+{%- if pv == '3' %}
 {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/*
 {%- endif %}
 {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(module) }}.py{% if pv != '3'%}*{% endif %}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -95,7 +95,11 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endfor %}
 {%- endif %}
 {%- if data.has_extension %}
-{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(data.underscored_name) }}
+{%- if data.has_packages %}
+{%- for package in data.packages %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
+{%- endfor %}
+{%- endif %}
 {%- if data.has_pth %}
 {{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
 {%- endif %}
@@ -103,7 +107,7 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
-{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.underscored_name) }}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}

--- a/pyp2rpm/templates/fedora_subdirs.spec
+++ b/pyp2rpm/templates/fedora_subdirs.spec
@@ -103,7 +103,7 @@ popd
 {%- endif %}
 {%- if data.py_modules %}
 {% for module in data.py_modules -%}
-{%- if pv == '3' -%}
+{%- if pv == '3' %}
 %dir {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/
 {{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/__pycache__/*
 {%- endif %}

--- a/pyp2rpm/templates/fedora_subdirs.spec
+++ b/pyp2rpm/templates/fedora_subdirs.spec
@@ -111,7 +111,11 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_extension %}
-{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ data.name | module_to_path(data.underscored_name) }}
+{%- if data.has_packages %}
+{%- for package in data.packages %}
+{{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
+{%- endfor %}
+{%- endif %}
 {%- if data.has_pth %}
 {{ '%{python2_sitearch}'|sitedir_for_python_version(pv) }}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
 {%- endif %}
@@ -119,7 +123,7 @@ popd
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
-{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.underscored_name) }}
+{{ '%{python2_sitelib}'|sitedir_for_python_version(pv) }}/{{ package | package_to_path(data.name) }}
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -1,12 +1,11 @@
 import os
-import re
 import glob
 import logging
 from virtualenvapi.manage import VirtualEnvironment
 import virtualenvapi.exceptions as ve
 
 from pyp2rpm.exceptions import VirtualenvFailException
-from pyp2rpm.settings import DEFAULT_PYTHON_VERSION
+from pyp2rpm.settings import DEFAULT_PYTHON_VERSION, MODULE_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -55,8 +54,6 @@ class DirsContent(object):
 
 class VirtualEnv(object):
 
-    modul_pattern = re.compile(r'\.py.?$')
-
     def __init__(self, name, temp_dir, name_convertor, base_python_version):
         self.name = name
         self.temp_dir = temp_dir
@@ -96,7 +93,7 @@ class VirtualEnv(object):
         except ValueError:
             raise VirtualenvFailException("Some of the DirsContent attributes is uninicialized")
         site_packages = site_packages_filter(diff.lib_sitepackages)
-        packages = set([p for p in site_packages if not self.modul_pattern.search(p)])
+        packages = set([p for p in site_packages if not p.endswith(MODULE_SUFFIXES)])
         py_modules = set([os.path.splitext(m)[0] for m in site_packages - packages])
         scripts = scripts_filter(list(diff.bindir))
         logger.debug('Packages from files differance in virtualenv: {0}.'.format(

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -1,6 +1,8 @@
 import os
 import glob
 import logging
+import pprint
+
 from virtualenvapi.manage import VirtualEnvironment
 import virtualenvapi.exceptions as ve
 
@@ -12,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def site_packages_filter(site_packages_list):
     '''Removes wheel .dist-info files'''
-    return set([x for x in site_packages_list if not x.split('.')[-1] == 'dist-info'])
+    return set([x for x in site_packages_list if not x.endswith(('dist-info', '.pth'))])
 
 
 def scripts_filter(scripts):
@@ -82,7 +84,6 @@ class VirtualEnv(object):
             raise VirtualenvFailException('Failed to install package to virtualenv')
         self.dirs_after_install.fill(self.temp_dir + '/venv/')
 
-    @property
     def get_dirs_differance(self):
         '''
         Makes final versions of site_packages and scripts using DirsContent
@@ -92,20 +93,17 @@ class VirtualEnv(object):
             diff = self.dirs_after_install - self.dirs_before_install
         except ValueError:
             raise VirtualenvFailException("Some of the DirsContent attributes is uninicialized")
+        self.data['has_pth'] = any([x for x in diff.lib_sitepackages if x.endswith('.pth')])
         site_packages = site_packages_filter(diff.lib_sitepackages)
-        packages = set([p for p in site_packages if not p.endswith(MODULE_SUFFIXES)])
-        py_modules = set([os.path.splitext(m)[0] for m in site_packages - packages])
-        scripts = scripts_filter(list(diff.bindir))
-        logger.debug('Packages from files differance in virtualenv: {0}.'.format(
-            packages))
-        logger.debug('py_modules from files differance in virtualenv: {0}.'.format(
-            py_modules))
-        logger.debug('Scripts from files differance in virtualenv: {0}.'.format(scripts))
-        return (packages, py_modules, scripts)
+        self.data['packages'] = set([p for p in site_packages if not p.endswith(MODULE_SUFFIXES)])
+        self.data['py_modules'] = set([os.path.splitext(m)[0]
+                                       for m in site_packages - self.data['packages']])
+        self.data['scripts'] = scripts_filter(list(diff.bindir))
+        logger.debug('Data from files differance in virtualenv:')
+        logger.debug(pprint.pformat(self.data))
 
     @property
     def get_venv_data(self):
         self.install_package_to_venv()
-        (self.data['packages'], self.data['py_modules'],
-         self.data['scripts']) = self.get_dirs_differance
+        self.get_dirs_differance()
         return self.data

--- a/tests/test_data/python-StructArray.spec
+++ b/tests/test_data/python-StructArray.spec
@@ -1,0 +1,56 @@
+# Created by pyp2rpm-3.2.1
+%global pypi_name StructArray
+
+Name:           python-%{pypi_name}
+Version:        0.1
+Release:        1%{?dist}
+Summary:        Fast operations on arrays of structured data
+
+License:        MIT
+URL:            http://matthewmarshall.org/projects/structarray/
+Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+ 
+BuildRequires:  python2-devel
+BuildRequires:  python-setuptools
+
+%description
+ StructArray StructArray allows you to perform fast arithmetic operations on
+arrays of structured (or unstructured) data.This library is useful for
+performing the same operation on every item in an I've included an example
+showing a simple particle engine. It animates 10,000 particles without much
+trouble.*This is the "release early" part of the "release early, release often"
+equation. It's ...
+
+%package -n     python2-%{pypi_name}
+Summary:        Fast operations on arrays of structured data
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+%description -n python2-%{pypi_name}
+ StructArray StructArray allows you to perform fast arithmetic operations on
+arrays of structured (or unstructured) data.This library is useful for
+performing the same operation on every item in an I've included an example
+showing a simple particle engine. It animates 10,000 particles without much
+trouble.*This is the "release early" part of the "release early, release often"
+equation. It's ...
+
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+
+%files -n python2-%{pypi_name}
+%doc 
+%{python2_sitearch}/structarray.so
+%{python2_sitearch}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%changelog
+* Thu Nov 24 2016 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
+- Initial package.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,6 +22,7 @@ class TestSpec(object):
         ('Jinja2', '-t epel6', 'python-Jinja2_epel6.spec'),
         ('buildkit', '-b2', 'python-buildkit.spec'),
     ])
+    @pytest.mark.spectest
     def test_spec(self, package, options, expected):
         with open(self.td_dir + expected) as fi:
             self.spec_content = fi.read()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,6 +21,7 @@ class TestSpec(object):
         ('Jinja2', '-t epel7', 'python-Jinja2_epel7.spec'),
         ('Jinja2', '-t epel6', 'python-Jinja2_epel6.spec'),
         ('buildkit', '-b2', 'python-buildkit.spec'),
+        ('StructArray', '-b2', 'python-StructArray.spec'),
     ])
     @pytest.mark.spectest
     def test_spec(self, package, options, expected):

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -323,7 +323,7 @@ class TestWheelMetadataExtractor(object):
                            ['BuildRequires', 'python-setuptools']]),
 
         (0, 'py_modules', set(['setuptools', '_markerlib', 'pkg_resources'])),
-        (0, 'packages', set(['setuptools'])),
+        (0, 'packages', set()),
         (0, 'scripts', set()),
         (0, 'home_page', 'https://bitbucket.org/pypa/setuptools'),
         (0, 'summary', 'Easily download, build, install, upgrade, and uninstall Python packages'),
@@ -339,7 +339,7 @@ class TestWheelMetadataExtractor(object):
         (1, 'build_deps', [['BuildRequires', 'python2-devel'],
                            ['BuildRequires', 'python-setuptools']]),
         (1, 'py_modules', set(['py2exe'])),
-        (1, 'packages', set(['py2exe'])),
+        (1, 'packages', set()),
         (1, 'scripts', set(['build_exe.exe', 'build_exe-script.py'])),
         (1, 'home_page', 'TODO:'),
         (1, 'summary', 'Build standalone executables for Windows (python 3 version)'),

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -66,13 +66,19 @@ class TestVirtualEnv(object):
         shutil.rmtree(self.temp_dir)
 
     @pytest.mark.parametrize(('bin_diff', 'package_diff', 'expected'), [
-        (set(['foo']), set(['foo']), (set(['foo']), set(), ['foo'])),
-        (set(['foo']), set(['foo.py', 'foo.pyc']), (set(), set(['foo']), ['foo'])),
-        (set([]), set(['foo.py']), (set(), set(['foo']), [])),
-        (set(['foo']), set([]), (set([]), set(), ['foo'])),
-        (set(), set(), (set(), set(), [])),
+        (set(['foo']), set(['foo']), (set(['foo']), set(), ['foo'], False)),
+        (set(['foo']), set(['foo.py', 'foo.pyc']),
+         (set(), set(['foo']), ['foo'], False)),
+        (set([]), set(['foo.py']), (set(), set(['foo']), [], False)),
+        (set(['foo']), set(["foo-pyX.Y-nspkg.pth"]),
+         (set([]), set(), ['foo'], True)),
+        (set(), set(), (set(), set(), [], False)),
     ])
     def test_get_dirs_differance(self, bin_diff, package_diff, expected):
         flexmock(DirsContent).should_receive('__sub__').and_return(
             DirsContent(bin_diff, package_diff))
-        assert self.venv.get_dirs_differance == expected
+        self.venv.get_dirs_differance()
+        assert ((self.venv.data['packages'],
+                 self.venv.data['py_modules'],
+                 self.venv.data['scripts'],
+                 self.venv.data['has_pth']) == expected)


### PR DESCRIPTION
- Improvement of packages and modules
    - dash in pkg name not replaced with underscore (virtualenv module extracts name in the correct form)
    - PyPI packages containing modules only
      
- Impovement of .pth files detection
    - packages without '.' in name containing .pth file (PasteDeploy)
    - packages containing '.' in name without .pth files (giturl.py)
    - py2 specific .pth files not added to python3 subpackage (zc.buildout)
- Marker of spec file test
- Encoding in mybin.py script