### PR TITLE
Make `-r` option work (#87)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build/
 dist/
 pyp2rpm.egg-info
 MANIFEST
+.tox/
+.cache/
+.eggs/
+tests/test_output/

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -33,11 +33,9 @@ def python_bin_for_python_version(name, version, default_string='__python2'):
         return name.replace(default_string, '__python{0}'.format(version))
 
 
-def macroed_pkg_name(pkg_name, name):
-    if pkg_name.startswith('python') and name == pkg_name:
-        # if (pypi) name starts with python also then we can't prefix python
-        # this would lead to python3-python-foo names like
-        return name
+def macroed_pkg_name(pkg_name, srcname):
+    if srcname:
+        return 'python-%{srcname}'
     elif pkg_name.startswith('python-'):
         return 'python-%{pypi_name}'
     else:
@@ -60,6 +58,7 @@ def package_to_path(package, module):
         return "%{pypi_name}"
     else:
         return package
+
 
 __all__ = [name_for_python_version,
            script_name_for_python_version,

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -34,12 +34,11 @@ def python_bin_for_python_version(name, version, default_string='__python2'):
 
 
 def macroed_pkg_name(pkg_name, srcname):
-    if srcname:
-        return 'python-%{srcname}'
-    elif pkg_name.startswith('python-'):
-        return 'python-%{pypi_name}'
+    macro = '%{srcname}' if srcname else '%{pypi_name}'
+    if pkg_name.startswith('python-'):
+        return 'python-{0}'.format(macro)
     else:
-        return '%{pypi_name}'
+        return macro
 
 
 def module_to_path(name, module):

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -155,11 +155,15 @@ class LocalMetadataExtractor(object):
         Returns:
             PackageData object containing the extracted data.
         """
-        data = PackageData(self.local_file,
-                           self.name,
-                           self.name_convertor.rpm_name(self.name)
-                           if self.rpm_name is None else self.rpm_name,
-                           self.version)
+        data = PackageData(
+            local_file=self.local_file,
+            name=self.name,
+            pkg_name=self.rpm_name or self.name_convertor.rpm_name(self.name),
+            version=self.version,
+            # Provide srcname if provided with -r or
+            # if pypi name is like python-<name>.
+            srcname=self.name_convertor.base_name(self.rpm_name or self.name)
+            if self.rpm_name or self.name.startswith('python') else None)
 
         with self.archive:
             data.set_from(self.data_from_archive)

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -156,7 +156,7 @@ class LocalMetadataExtractor(object):
         - name was provided with -r option
         - pypi name is like python-<name>
         """
-        if self.rpm_name or self.name.startswith('python'):
+        if self.rpm_name or self.name.startswith(('python-', 'Python-')):
             return self.name_convertor.base_name(self.rpm_name or self.name)
 
     @pypi_metadata_extension

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -415,7 +415,7 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
 
         for directory in candidate_dirs:  # search for conf.py in the dirs (TODO: what if more are found?)
             contains_conf_py = self.archive.get_files_re(
-                r'{0}/conf.py'.format(re.escape(directory)), full_path=True)
+                r'{0}/conf.py$'.format(re.escape(directory)), full_path=True)
             in_tests = 'tests' in directory.split(os.sep)
             if contains_conf_py and not in_tests:
                 return directory

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -148,6 +148,17 @@ class LocalMetadataExtractor(object):
         """
         return self.archive.has_file_with_suffix(settings.EXTENSION_SUFFIXES)
 
+    @property
+    def srcname(self):
+        """Return srcname for the macro if the pypi name should be changed.
+
+        Those cases are:
+        - name was provided with -r option
+        - pypi name is like python-<name>
+        """
+        if self.rpm_name or self.name.startswith('python'):
+            return self.name_convertor.base_name(self.rpm_name or self.name)
+
     @pypi_metadata_extension
     @venv_metadata_extension
     def extract_data(self):
@@ -160,10 +171,7 @@ class LocalMetadataExtractor(object):
             name=self.name,
             pkg_name=self.rpm_name or self.name_convertor.rpm_name(self.name),
             version=self.version,
-            # Provide srcname if provided with -r or
-            # if pypi name is like python-<name>.
-            srcname=self.name_convertor.base_name(self.rpm_name or self.name)
-            if self.rpm_name or self.name.startswith('python') else None)
+            srcname=self.srcname)
 
         with self.archive:
             data.set_from(self.data_from_archive)
@@ -175,7 +183,6 @@ class LocalMetadataExtractor(object):
         # if virtualenv is disabled
         if virtualenv is None and getattr(data, "packages") == set():
             data.packages = set([data.name])
-
 
         return data
 

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -401,19 +401,17 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
         Returns:
             Full path to sphinx documentation dir inside the archive, or None if there is no such.
         """
-        sphinx_dir = None
-
         # search for sphinx dir doc/ or docs/ under the first directory in
         # archive (e.g. spam-1.0.0/doc)
         candidate_dirs = self.archive.get_directories_re(
             settings.SPHINX_DIR_RE, full_path=True)
-        for d in candidate_dirs:  # search for conf.py in the dirs (TODO: what if more are found?)
-            contains_conf_py = len(self.archive.get_files_re(
-                r'{0}/conf.py'.format(re.escape(d)), full_path=True)) > 0
-            if contains_conf_py:
-                sphinx_dir = d
 
-        return sphinx_dir
+        for directory in candidate_dirs:  # search for conf.py in the dirs (TODO: what if more are found?)
+            contains_conf_py = self.archive.get_files_re(
+                r'{0}/conf.py'.format(re.escape(directory)), full_path=True)
+            in_tests = 'tests' in directory.split(os.sep)
+            if contains_conf_py and not in_tests:
+                return directory
 
     @property
     def data_from_archive(self):

--- a/pyp2rpm/name_convertor.py
+++ b/pyp2rpm/name_convertor.py
@@ -17,7 +17,7 @@ class NameConvertor(object):
 
     def __init__(self, distro):
         self.distro = distro
-        self.reg_start = re.compile(r'^python(\d*|)-(.*)')
+        self.reg_start = re.compile(r'^[Pp]ython(\d*|)-(.*)')
         self.reg_end = re.compile(r'(.*)-(python)(\d*|)$')
 
     @staticmethod

--- a/pyp2rpm/name_convertor.py
+++ b/pyp2rpm/name_convertor.py
@@ -58,7 +58,7 @@ class NameConvertor(object):
         return versioned_name
 
     def rpm_name(self, name, python_version=settings.DEFAULT_PYTHON_VERSION):
-        """Returns name of the package coverted to (possibly) correct package 
+        """Returns name of the package coverted to (possibly) correct package
            name according to Packaging Guidelines.
         Args:
             name: name to convert

--- a/pyp2rpm/package_data.py
+++ b/pyp2rpm/package_data.py
@@ -23,10 +23,11 @@ class PackageData(object):
 
     """A simple object that carries data about a package."""
 
-    def __init__(self, local_file, name, pkg_name, version, md5='', url=''):
+    def __init__(self, local_file, name, pkg_name, version, md5='', url='', srcname=None):
         object.__setattr__(self, 'data', {})
         self.data['local_file'] = local_file
         self.data['name'] = name
+        self.data['srcname'] = srcname
         self.data['pkg_name'] = pkg_name
         self.data['version'] = version
         self.data['python_versions'] = []

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -1,11 +1,14 @@
 {{ data.credit_line }}
 {% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
 %global pypi_name {{ data.name }}
+{%- if data.srcname %}
+%global srcname {{ data.srcname }}
+{%- endif %}
 {%- for pv in data.python_versions %}
 %global with_python{{ pv }} 1
 {%- endfor %}
 
-Name:           {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(data.base_python_version) }}
+Name:           {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(data.base_python_version) }}
 Version:        {{ data.version }}
 Release:        1%{?dist}
 Summary:        {{ data.summary }}
@@ -26,11 +29,11 @@ BuildArch:      noarch
 %description
 {{ data.description|truncate(400)|wordwrap }}
 {% call(pv) for_python_versions(data.python_versions) -%}
-%package -n     {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%package -n     {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 Summary:        {{ data.summary }}
 {{ dependencies(data.runtime_deps, True, pv, pv) }}
 
-%description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 {{ data.description|truncate(400)|wordwrap }}
 {%- endcall %}
 
@@ -102,7 +105,7 @@ popd
 {%- endif %}
 
 {% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
-%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
+%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}{% endif %}
 %doc {% if data.sphinx_dir %}html {% endif %}{{ data.doc_files|join(' ') }}
 {%- if data.scripts %}
 {%- for script in data.scripts %}

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -78,7 +78,7 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endfor %}
 {%- endif %}
 {% for pv in [data.base_python_version] + data.python_versions %}
-%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True, True) }} 
+%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True, True) }}
 %doc {{data.doc_files|join(' ') }}
 {%- for script in data.scripts %}
 {%- if pv == data.base_python_version %}

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -1,8 +1,11 @@
 {{ data.credit_line }}
 {% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
 %global pypi_name {{ data.name }}
+{%- if data.srcname %}
+%global srcname {{ data.srcname }}
+{%- endif %}
 
-Name:           {{ data.pkg_name|macroed_pkg_name(data.name) }}
+Name:           {{ data.pkg_name|macroed_pkg_name(data.srcname) }}
 Version:        {{ data.version }}
 Release:        1%{?dist}
 Summary:        {{ data.summary }}
@@ -24,10 +27,10 @@ use_with=False, epel=True) }}
 %description
 {{ data.description|truncate(400)|wordwrap }}
 {% for pv in ([data.base_python_version] + data.python_versions) %}
-%package -n     {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True, True)}}
+%package -n     {{data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True, True)}}
 Summary:        {{ data.summary }}
 {{ dependencies(data.runtime_deps, True, pv, pv, use_with=False, epel=True) }}
-%description -n {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True, True)}}
+%description -n {{data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True, True)}}
 {{ data.description|truncate(400)|wordwrap }}
 {% endfor -%}
 {%- if data.sphinx_dir %}
@@ -75,7 +78,7 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endfor %}
 {%- endif %}
 {% for pv in [data.base_python_version] + data.python_versions %}
-%files -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True, True) }} 
+%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True, True) }} 
 %doc {{data.doc_files|join(' ') }}
 {%- for script in data.scripts %}
 {%- if pv == data.base_python_version %}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -1,8 +1,11 @@
 {{ data.credit_line }}
 {% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
 %global pypi_name {{ data.name }}
+{%- if data.srcname %}
+%global srcname {{ data.srcname }}
+{%- endif %}
 
-Name:           {{ data.pkg_name|macroed_pkg_name(data.name) }}
+Name:           {{ data.pkg_name|macroed_pkg_name(data.srcname) }}
 Version:        {{ data.version }}
 Release:        1%{?dist}
 Summary:        {{ data.summary }}
@@ -22,17 +25,17 @@ BuildArch:      noarch
 %description
 {{ data.description|truncate(400)|wordwrap }}
 {% for pv in ([data.base_python_version] + data.python_versions) %}
-%package -n     {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }}
+%package -n     {{data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}
 Summary:        {{ data.summary }}
-%{?python_provide:%python_provide {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True)}}}
+%{?python_provide:%python_provide {{data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True)}}}
 {{ dependencies(data.runtime_deps, True, pv, pv) }}
-%description -n {{data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }}
+%description -n {{data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}
 {{ data.description|truncate(400)|wordwrap }}
 {% endfor -%}
 {%- if data.sphinx_dir %}
-%package -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }}-doc
+%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
 Summary:        {{ data.name }} documentation
-%description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }}-doc
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
 Documentation for {{ data.name }}
 {%- endif %}
 
@@ -74,7 +77,7 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endfor %}
 {%- endif %}
 {% for pv in [data.base_python_version] + data.python_versions %}
-%files -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }} 
+%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }} 
 {%- if data.doc_license %}
 %license {{data.doc_license|join(' ')}}
 {%- endif %}
@@ -117,7 +120,7 @@ ln -sf %{_bindir}/{{ script|script_name_for_python_version(pv) }} %{buildroot}/%
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}
-%files -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv, True) }}-doc
+%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
 %doc html 
 {% endif %}
 %changelog

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -77,7 +77,7 @@ ln -s %{_bindir}/{{ script|script_name_for_python_version(pv, True) }} %{buildro
 {%- endfor %}
 {%- endif %}
 {% for pv in [data.base_python_version] + data.python_versions %}
-%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }} 
+%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}
 {%- if data.doc_license %}
 %license {{data.doc_license|join(' ')}}
 {%- endif %}

--- a/pyp2rpm/templates/fedora_subdirs.spec
+++ b/pyp2rpm/templates/fedora_subdirs.spec
@@ -1,11 +1,14 @@
 {{ data.credit_line }}
 {% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
 %global pypi_name {{ data.name }}
+{%- if data.srcname %}
+%global srcname {{ data.srcname }}
+{%- endif %}
 {%- for pv in data.python_versions %}
 %global with_python{{ pv }} 1
 {%- endfor %}
 
-Name:           {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(data.base_python_version) }}
+Name:           {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(data.base_python_version) }}
 Version:        {{ data.version }}
 Release:        1%{?dist}
 Summary:        {{ data.summary }}
@@ -26,11 +29,11 @@ BuildArch:      noarch
 %description
 {{ data.description|truncate(400)|wordwrap }}
 {% call(pv) for_python_versions(data.python_versions) -%}
-%package -n     {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%package -n     {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 Summary:        {{ data.summary }}
 {{ dependencies(data.runtime_deps, True, pv, pv) }}
 
-%description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 {{ data.description|truncate(400)|wordwrap }}
 {%- endcall %}
 %prep
@@ -94,7 +97,7 @@ popd
 {%- endcall %}
 {%- endif %}
 {% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
-%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
+%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}{% endif %}
 %doc {% if data.sphinx_dir %}html {% endif %} {{data.doc_files|join(' ') }}
 {%- if data.scripts %}
 {%- for script in data.scripts %}

--- a/pyp2rpm/templates/mageia.spec
+++ b/pyp2rpm/templates/mageia.spec
@@ -1,6 +1,9 @@
 {{ data.credit_line }}
 {% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
 %global pypi_name {{ data.name }}
+{%- if data.srcname %}
+%global srcname {{ data.srcname }}
+{%- endif %}
 {%- for pv in data.python_versions %}
 %global with_python{{ pv }} 1
 {%- endfor %}
@@ -28,11 +31,11 @@ BuildArch:      noarch
 %description
 {{ data.description|truncate(400)|wordwrap }}
 {% call(pv) for_python_versions(data.python_versions) -%}
-%package -n     {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%package -n     {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 Summary:        {{ data.summary }}
 {{ dependencies(data.runtime_deps, True, pv, pv) }}
 
-%description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 {{ data.description|truncate(400)|wordwrap }}
 {%- endcall %}
 
@@ -90,7 +93,7 @@ popd
 
 
 {% call(pv) for_python_versions([data.base_python_version] + data.python_versions, data.base_python_version) -%}
-%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
+%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}{% endif %}
 %doc {% if data.sphinx_dir %}html {% endif %}{{ data.doc_files|join(' ') }}
 {%- if data.scripts %}
 {%- for script in data.scripts %}

--- a/pyp2rpm/templates/pld.spec
+++ b/pyp2rpm/templates/pld.spec
@@ -69,11 +69,11 @@ BuildRoot:	%{tmpdir}/%{name}-%{version}-root-%(id -u -n)
 {{ data.description|truncate(400)|wordwrap }}
 
 {% call(pv) for_python_versions(data.python_versions, use_with=False) -%}
-%package -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 Summary:	{{ data.summary }}
 Group:		Libraries/Python
 
-%description -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}
 {{ data.description|truncate(400)|wordwrap }}
 {%- endcall %}
 
@@ -123,7 +123,7 @@ mv $RPM_BUILD_ROOT%{_bindir}/{{ script }} $RPM_BUILD_ROOT%{_bindir}/{{ script|sc
 rm -rf $RPM_BUILD_ROOT
 
 {% call(pv, v) foreach_python_versions(use_with=True) -%}
-%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.name)|name_for_python_version(pv) }}{% endif %}
+%files{% if pv != data.base_python_version %} -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv) }}{% endif %}
 %defattr(644,root,root,755)
 
 %doc {% if data.sphinx_dir %}html {% endif %}{{ data.doc_files|join(' ') }}

--- a/tests/test_data/python-Jinja2_epel7.spec
+++ b/tests/test_data/python-Jinja2_epel7.spec
@@ -76,12 +76,12 @@ rm -rf html/.{doctrees,buildinfo}
 %{__python2} setup.py install --skip-build --root %{buildroot}
 
 
-%files -n python2-%{pypi_name} 
+%files -n python2-%{pypi_name}
 %doc README.rst
 %{python2_sitelib}/jinja2
 %{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
-%files -n python%{python3_pkgversion}-%{pypi_name} 
+%files -n python%{python3_pkgversion}-%{pypi_name}
 %doc README.rst
 %{python3_sitelib}/jinja2
 %{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info

--- a/tests/test_data/python-StructArray.spec
+++ b/tests/test_data/python-StructArray.spec
@@ -22,7 +22,7 @@ trouble.*This is the "release early" part of the "release early, release often"
 equation. It's ...
 
 %package -n     python2-%{pypi_name}
-Summary:        Fast operations on arrays of structured data
+Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{pypi_name}}
 
 %description -n python2-%{pypi_name}

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -1,0 +1,155 @@
+# Created by pyp2rpm-3.2.1
+%global pypi_name Sphinx
+%global srcname sphinx
+
+Name:           python-%{srcname}
+Version:        1.4.9
+Release:        1%{?dist}
+Summary:        Python documentation generator
+
+License:        BSD
+URL:            http://sphinx-doc.org/
+Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python2-devel
+BuildRequires:  python-setuptools
+BuildRequires:  python-sphinx
+ 
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+
+%description
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl. It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+Sphinx uses ...
+
+%package -n     python2-%{srcname}
+Summary:        Python documentation generator
+%{?python_provide:%python_provide python2-%{srcname}}
+ 
+Requires:       python-six >= 1.5
+Requires:       python-Jinja2 >= 2.3
+Requires:       python-Pygments >= 2.0
+Requires:       python-docutils >= 0.11
+Requires:       python-snowballstemmer >= 1.1
+Conflicts:      python-babel = 2.0
+Requires:       python-babel >= 1.3
+Requires:       python-alabaster < 0.8
+Requires:       python-alabaster >= 0.7
+Requires:       python-imagesize
+Requires:       python-setuptools
+%description -n python2-%{srcname}
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl. It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+Sphinx uses ...
+
+%package -n     python3-%{srcname}
+Summary:        Python documentation generator
+%{?python_provide:%python_provide python3-%{srcname}}
+ 
+Requires:       python3-six >= 1.5
+Requires:       python3-Jinja2 >= 2.3
+Requires:       python3-Pygments >= 2.0
+Requires:       python3-docutils >= 0.11
+Requires:       python3-snowballstemmer >= 1.1
+Conflicts:      python3-babel = 2.0
+Requires:       python3-babel >= 1.3
+Requires:       python3-alabaster < 0.8
+Requires:       python3-alabaster >= 0.7
+Requires:       python3-imagesize
+Requires:       python3-setuptools
+%description -n python3-%{srcname}
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl. It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+Sphinx uses ...
+
+%package -n python-%{srcname}-doc
+Summary:        Sphinx documentation
+%description -n python-%{srcname}-doc
+Documentation for Sphinx
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%py3_build
+# generate html docs 
+sphinx-build doc html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install.
+%py3_install
+cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-3
+ln -sf %{_bindir}/sphinx-quickstart-3 %{buildroot}/%{_bindir}/sphinx-quickstart-%{python3_version}
+cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-3
+ln -sf %{_bindir}/sphinx-apidoc-3 %{buildroot}/%{_bindir}/sphinx-apidoc-%{python3_version}
+cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-3
+ln -sf %{_bindir}/sphinx-build-3 %{buildroot}/%{_bindir}/sphinx-build-%{python3_version}
+cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-3
+ln -sf %{_bindir}/sphinx-autogen-3 %{buildroot}/%{_bindir}/sphinx-autogen-%{python3_version}
+
+%py2_install
+cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-2
+ln -sf %{_bindir}/sphinx-quickstart-2 %{buildroot}/%{_bindir}/sphinx-quickstart-%{python2_version}
+cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-2
+ln -sf %{_bindir}/sphinx-apidoc-2 %{buildroot}/%{_bindir}/sphinx-apidoc-%{python2_version}
+cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-2
+ln -sf %{_bindir}/sphinx-build-2 %{buildroot}/%{_bindir}/sphinx-build-%{python2_version}
+cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-2
+ln -sf %{_bindir}/sphinx-autogen-2 %{buildroot}/%{_bindir}/sphinx-autogen-%{python2_version}
+
+
+%files -n python2-%{srcname}
+%license LICENSE
+%doc README.rst
+%{_bindir}/sphinx-quickstart
+%{_bindir}/sphinx-quickstart-2
+%{_bindir}/sphinx-quickstart-%{python2_version}
+%{_bindir}/sphinx-apidoc
+%{_bindir}/sphinx-apidoc-2
+%{_bindir}/sphinx-apidoc-%{python2_version}
+%{_bindir}/sphinx-build
+%{_bindir}/sphinx-build-2
+%{_bindir}/sphinx-build-%{python2_version}
+%{_bindir}/sphinx-autogen
+%{_bindir}/sphinx-autogen-2
+%{_bindir}/sphinx-autogen-%{python2_version}
+%{python2_sitelib}/sphinx
+%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python3-%{srcname}
+%license LICENSE
+%doc README.rst
+%{_bindir}/sphinx-quickstart-3
+%{_bindir}/sphinx-quickstart-%{python3_version}
+%{_bindir}/sphinx-apidoc-3
+%{_bindir}/sphinx-apidoc-%{python3_version}
+%{_bindir}/sphinx-build-3
+%{_bindir}/sphinx-build-%{python3_version}
+%{_bindir}/sphinx-autogen-3
+%{_bindir}/sphinx-autogen-%{python3_version}
+%{python3_sitelib}/sphinx
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python-%{srcname}-doc
+%doc html 
+
+%changelog
+* Fri Nov 25 2016 Iryna Shcherbina <ishcherb@redhat.com> - 1.4.9-1
+- Initial package.

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -3,7 +3,7 @@
 %global srcname sphinx
 
 Name:           python-%{srcname}
-Version:        1.4.9
+Version:        1.5
 Release:        1%{?dist}
 Summary:        Python documentation generator
 
@@ -28,7 +28,7 @@ project documentation, but C/C++ is supported as well, and more languages are
 Sphinx uses ...
 
 %package -n     python2-%{srcname}
-Summary:        Python documentation generator
+Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{srcname}}
  
 Requires:       python-six >= 1.5
@@ -41,6 +41,7 @@ Requires:       python-babel >= 1.3
 Requires:       python-alabaster < 0.8
 Requires:       python-alabaster >= 0.7
 Requires:       python-imagesize
+Requires:       python-requests
 Requires:       python-setuptools
 %description -n python2-%{srcname}
 Sphinx is a tool that makes it easy to create intelligent and beautiful
@@ -51,7 +52,7 @@ project documentation, but C/C++ is supported as well, and more languages are
 Sphinx uses ...
 
 %package -n     python3-%{srcname}
-Summary:        Python documentation generator
+Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{srcname}}
  
 Requires:       python3-six >= 1.5
@@ -64,6 +65,7 @@ Requires:       python3-babel >= 1.3
 Requires:       python3-alabaster < 0.8
 Requires:       python3-alabaster >= 0.7
 Requires:       python3-imagesize
+Requires:       python3-requests
 Requires:       python3-setuptools
 %description -n python3-%{srcname}
 Sphinx is a tool that makes it easy to create intelligent and beautiful
@@ -95,24 +97,24 @@ rm -rf html/.{doctrees,buildinfo}
 # Must do the subpackages' install first because the scripts in /usr/bin are
 # overwritten with every setup.py install.
 %py3_install
-cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-3
-ln -sf %{_bindir}/sphinx-quickstart-3 %{buildroot}/%{_bindir}/sphinx-quickstart-%{python3_version}
-cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-3
-ln -sf %{_bindir}/sphinx-apidoc-3 %{buildroot}/%{_bindir}/sphinx-apidoc-%{python3_version}
-cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-3
-ln -sf %{_bindir}/sphinx-build-3 %{buildroot}/%{_bindir}/sphinx-build-%{python3_version}
-cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-3
-ln -sf %{_bindir}/sphinx-autogen-3 %{buildroot}/%{_bindir}/sphinx-autogen-%{python3_version}
+cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-%{python3_version}
+ln -s %{_bindir}/sphinx-quickstart-%{python3_version} %{buildroot}/%{_bindir}/sphinx-quickstart-3
+cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-%{python3_version}
+ln -s %{_bindir}/sphinx-apidoc-%{python3_version} %{buildroot}/%{_bindir}/sphinx-apidoc-3
+cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-%{python3_version}
+ln -s %{_bindir}/sphinx-build-%{python3_version} %{buildroot}/%{_bindir}/sphinx-build-3
+cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-%{python3_version}
+ln -s %{_bindir}/sphinx-autogen-%{python3_version} %{buildroot}/%{_bindir}/sphinx-autogen-3
 
 %py2_install
-cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-2
-ln -sf %{_bindir}/sphinx-quickstart-2 %{buildroot}/%{_bindir}/sphinx-quickstart-%{python2_version}
-cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-2
-ln -sf %{_bindir}/sphinx-apidoc-2 %{buildroot}/%{_bindir}/sphinx-apidoc-%{python2_version}
-cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-2
-ln -sf %{_bindir}/sphinx-build-2 %{buildroot}/%{_bindir}/sphinx-build-%{python2_version}
-cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-2
-ln -sf %{_bindir}/sphinx-autogen-2 %{buildroot}/%{_bindir}/sphinx-autogen-%{python2_version}
+cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-%{python2_version}
+ln -s %{_bindir}/sphinx-quickstart-%{python2_version} %{buildroot}/%{_bindir}/sphinx-quickstart-2
+cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-%{python2_version}
+ln -s %{_bindir}/sphinx-apidoc-%{python2_version} %{buildroot}/%{_bindir}/sphinx-apidoc-2
+cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-%{python2_version}
+ln -s %{_bindir}/sphinx-build-%{python2_version} %{buildroot}/%{_bindir}/sphinx-build-2
+cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-%{python2_version}
+ln -s %{_bindir}/sphinx-autogen-%{python2_version} %{buildroot}/%{_bindir}/sphinx-autogen-2
 
 
 %files -n python2-%{srcname}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -5,15 +5,15 @@ from pyp2rpm.filters import macroed_pkg_name, name_for_python_version
 
 class TestFilters(object):
 
-    @pytest.mark.parametrize(('pkg_name', 'name', 'version', 'default_number', 'expected'), [
-        ('python-Jinja2', 'Jinja2', '2', False, 'python-%{pypi_name}'),
-        ('python-Jinja2', 'Jinja2', '2', True, 'python2-%{pypi_name}'),
-        ('python-Jinja2', 'Jinja2', '3', False, 'python3-%{pypi_name}'),
-        ('python-Jinja2', 'Jinja2', '3', True, 'python3-%{pypi_name}'),
-        ('python-stdnum', 'python-stdnum', '2', False, 'python-stdnum'),
-        ('python-stdnum', 'python-stdnum', '2', True, 'python2-stdnum'),
-        ('python-stdnum', 'python-stdnum', '3', False, 'python3-stdnum')
+    @pytest.mark.parametrize(('pkg_name', 'srcname', 'version', 'default_number', 'expected'), [
+        ('python-Jinja2', None, '2', False, 'python-%{pypi_name}'),
+        ('python-Jinja2', None, '2', True, 'python2-%{pypi_name}'),
+        ('python-Jinja2', None, '3', False, 'python3-%{pypi_name}'),
+        ('python-Jinja2', None, '3', True, 'python3-%{pypi_name}'),
+        ('python-stdnum', 'stdnum', '2', False, 'python-%{srcname}'),
+        ('python-stdnum', 'stdnum', '2', True, 'python2-%{srcname}'),
+        ('python-stdnum', 'stdnum', '3', False, 'python3-%{srcname}')
     ])
-    def test_macroed_pkg_name(self, pkg_name, name, version, default_number, expected):
+    def test_macroed_pkg_name(self, pkg_name, srcname, version, default_number, expected):
         assert name_for_python_version(macroed_pkg_name(
-            pkg_name, name), version, default_number) == expected
+            pkg_name, srcname), version, default_number) == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,8 +2,6 @@ import pytest
 import os
 from scripttest import TestFileEnvironment
 
-from pyp2rpm.bin import main
-
 tests_dir = os.path.split(os.path.abspath(__file__))[0]
 
 
@@ -22,6 +20,7 @@ class TestSpec(object):
         ('Jinja2', '-t epel6', 'python-Jinja2_epel6.spec'),
         ('buildkit', '-b2', 'python-buildkit.spec'),
         ('StructArray', '-b2', 'python-StructArray.spec'),
+        ('Sphinx', '-r python-sphinx', 'python-sphinx.spec'),
     ])
     @pytest.mark.spectest
     def test_spec(self, package, options, expected):
@@ -29,7 +28,7 @@ class TestSpec(object):
             self.spec_content = fi.read()
         res = self.env.run('{0} {1} {2}'.format(self.exe, package, options))
         # changelog have to be cut from spec files
-        assert ''.join(res.stdout.split('\n')[1:-4]) == ''.join(self.spec_content.split('\n')[1:-4])
+        assert set(res.stdout.split('\n')[1:-4]) == set(self.spec_content.split('\n')[1:-4])
 
 
 class TestSrpm(object):


### PR DESCRIPTION
- Introduce `%{srcname}` macro to be used alongside `%{pypi_name}` if the  package name is to be changed (applies also for packages already starting with `python-` or `Python-` in PyPI)
- Fix filters tests to work with the new signature for `macroed_pkg_name`
- Add a new integration test for `python-sphinx.spec`
- Corner case: fix searching for Sphinx directory, when it is tested itself (another `doc/conf.py` in tests folder)

Fixes issues #87 and #66.