### PR TITLE
Fix locating `setup.py` (Issue #95)

### DIFF
--- a/pyp2rpm/archive.py
+++ b/pyp2rpm/archive.py
@@ -55,6 +55,9 @@ class ZipWrapper(object):
     def getmembers(self, *args, **kwargs):
         return self._wrapped_obj.infolist(*args, **kwargs)
 
+    def getnames(self, *args, **kwargs):
+        return self._wrapped_obj.namelist(*args, **kwargs)
+
     def extractfile(self, *args, **kwargs):
         return self._wrapped_obj.open(*args, **kwargs)
 
@@ -252,6 +255,12 @@ class Archive(object):
                         found.add(to_match)
 
         return list(found)
+
+    @property
+    def top_directory(self):
+        """Return the name of the archive topmost directory."""
+        if self.handle:
+            return os.path.commonprefix(self.handle.getnames()).rstrip('/')
 
     @property
     def json_wheel_metadata(self):

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -223,6 +223,8 @@ class LocalMetadataExtractor(object):
         (archive_data['doc_files'],
          archive_data['doc_license']) = self.separate_license_files(self.doc_files)
 
+        archive_data['dirname'] = self.archive.top_directory
+
         return archive_data
 
 
@@ -265,7 +267,8 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
 
     def get_setup_py(self, directory):
         try:
-            return glob.glob(directory + "/{0}*/".format(self.name) + 'setup.py')[0]
+            return glob.glob("{0}/{1}*/setup.py".format(
+                directory, self.archive.top_directory or self.name))[0]
         except IndexError:
             sys.stderr.write(
                 "setup.py not found, maybe local_file is not proper source archive.\n")

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -41,7 +41,7 @@ Documentation for {{ data.name }}
 {%- endif %}
 
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -n {{ data.dirname|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}')|default('%{pypi_name}-%{version}', true) }}
 {%- if data.has_bundled_egg_info %}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -40,7 +40,7 @@ Documentation for {{ data.name }}
 {%- endif %}
 
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -n {{ data.dirname|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}')|default('%{pypi_name}-%{version}', true) }}
 {%- if data.has_bundled_egg_info %}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -3,7 +3,7 @@
 %global srcname sphinx
 
 Name:           python-%{srcname}
-Version:        1.5
+Version:        1.5.1
 Release:        1%{?dist}
 Summary:        Python documentation generator
 

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -3,7 +3,7 @@
 %global srcname sphinx
 
 Name:           python-%{srcname}
-Version:        1.5.1
+Version:        1.5
 Release:        1%{?dist}
 Summary:        Python documentation generator
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,13 +14,13 @@ class TestSpec(object):
         self.env = TestFileEnvironment('{0}/test_output/'.format(tests_dir))
 
     @pytest.mark.parametrize(('package', 'options', 'expected'), [
-        ('Jinja2', '', 'python-Jinja2.spec'),
-        ('Jinja2', '-b3', 'python-Jinja2_base.spec'),
-        ('Jinja2', '-t epel7', 'python-Jinja2_epel7.spec'),
-        ('Jinja2', '-t epel6', 'python-Jinja2_epel6.spec'),
-        ('buildkit', '-b2', 'python-buildkit.spec'),
-        ('StructArray', '-b2', 'python-StructArray.spec'),
-        ('Sphinx', '-r python-sphinx', 'python-sphinx.spec'),
+        ('Jinja2', '-v2.8', 'python-Jinja2.spec'),
+        ('Jinja2', '-v2.8 -b3', 'python-Jinja2_base.spec'),
+        ('Jinja2', '-v2.8 -t epel7', 'python-Jinja2_epel7.spec'),
+        ('Jinja2', '-v2.8 -t epel6', 'python-Jinja2_epel6.spec'),
+        ('buildkit', '-v0.2.2 -b2', 'python-buildkit.spec'),
+        ('StructArray', '-v0.1 -b2', 'python-StructArray.spec'),
+        ('Sphinx', '-v1.5 -r python-sphinx', 'python-sphinx.spec'),
     ])
     @pytest.mark.spectest
     def test_spec(self, package, options, expected):


### PR DESCRIPTION
The problem with the listed packages is that the archive name differs from the PyPI name.

Take [ndg-httpsclient](https://pypi.python.org/pypi/ndg-httpsclient). The downloaded tar is `ndg_httpsclient-0.4.2.tar.gz`. As we solely depend on the PyPI name, we assume that the package will be extracted into `ndg-httpsclient-0.4.2`, which causes errors when locating `setup.py` and generating a spec file. Also the build later fails in `%prep` section in `%autosetup` where we also depend on PyPi name.

* fix matching `setup.py` file
* fix `%autosetup` to change into the unpacked directory

Tested the fixes in copr on the set of packages reported in the issue (and a couple of other packageswith the same issue, found during testing): https://copr.fedorainfracloud.org/coprs/ishcherb/pypi_builds1/packages/

Fixes #95.