### PR TITLE
Fix converting corner cases like numpy (Issue #97)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
+- '3.6'
+- 'nightly'
 
 cache:
   directories:

--- a/command/extract_dist.py
+++ b/command/extract_dist.py
@@ -48,7 +48,8 @@ class extract_dist(Command):
         is specified, assigns metadata dictionary to class_metadata variable otherwise.
         """
         if self.stdout:
-            sys.stdout.write("extracted json data:\n" + json.dumps(self.metadata))
+            sys.stdout.write("extracted json data:\n" + json.dumps(
+                self.metadata, default=to_str))
         else:
             extract_dist.class_metadata = self.metadata
 
@@ -69,6 +70,7 @@ def to_list(var):
 
 def to_str(var):
     """Similar to to_list function, but for string attributes."""
-    if not isinstance(var, str):
-        return 'TODO'
-    return var
+    try:
+        return str(var)
+    except TypeError:
+        raise ValueError("{} cannot be converted to string.".format(var))

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -318,7 +318,10 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
 
     @property
     def py_modules(self):
-        return set(self.metadata['py_modules'])
+        try:
+            return set(self.metadata['py_modules'])
+        except TypeError:
+            return set()
 
     @property
     def scripts(self):

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -79,7 +79,7 @@ class VirtualEnv(object):
         dependencies
         '''
         try:
-            self.env.install(self.name, options=["--no-deps"])
+            self.env.install(self.name, force=True, options=["--no-deps"])
         except (ve.PackageInstallationException, ve.VirtualenvReadonlyException):
             raise VirtualenvFailException('Failed to install package to virtualenv')
         self.dirs_after_install.fill(self.temp_dir + '/venv/')

--- a/tests/test_data/python-Jinja2.spec
+++ b/tests/test_data/python-Jinja2.spec
@@ -24,7 +24,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n     python2-%{pypi_name}
 Summary:        %{summary}
@@ -37,7 +37,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n     python3-%{pypi_name}
 Summary:        %{summary}
@@ -50,7 +50,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n python-%{pypi_name}-doc
 Summary:        Jinja2 documentation

--- a/tests/test_data/python-Jinja2_base.spec
+++ b/tests/test_data/python-Jinja2_base.spec
@@ -21,7 +21,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n     python3-%{pypi_name}
 Summary:        %{summary}
@@ -34,7 +34,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n python-%{pypi_name}-doc
 Summary:        Jinja2 documentation

--- a/tests/test_data/python-Jinja2_epel6.spec
+++ b/tests/test_data/python-Jinja2_epel6.spec
@@ -23,7 +23,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 
 %prep

--- a/tests/test_data/python-Jinja2_epel7.spec
+++ b/tests/test_data/python-Jinja2_epel7.spec
@@ -24,7 +24,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n     python2-%{pypi_name}
 Summary:        A small but fast and easy to use stand-alone template engine written in pure python
@@ -36,7 +36,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        A small but fast and easy to use stand-alone template engine written in pure python
@@ -48,7 +48,7 @@ inspired nonXML syntax but supports inline expressions and an optional
 sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
 extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
 content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
-user.username }}</a></li> {% ...
+user.username }}</a></li> {%...
 
 %package -n python-%{pypi_name}-doc
 Summary:        Jinja2 documentation

--- a/tests/test_data/python-StructArray.spec
+++ b/tests/test_data/python-StructArray.spec
@@ -19,7 +19,7 @@ arrays of structured (or unstructured) data.This library is useful for
 performing the same operation on every item in an I've included an example
 showing a simple particle engine. It animates 10,000 particles without much
 trouble.*This is the "release early" part of the "release early, release often"
-equation. It's ...
+equation. It's...
 
 %package -n     python2-%{pypi_name}
 Summary:        %{summary}
@@ -31,7 +31,7 @@ arrays of structured (or unstructured) data.This library is useful for
 performing the same operation on every item in an I've included an example
 showing a simple particle engine. It animates 10,000 particles without much
 trouble.*This is the "release early" part of the "release early, release often"
-equation. It's ...
+equation. It's...
 
 
 %prep

--- a/tests/test_data/python-buildkit.spec
+++ b/tests/test_data/python-buildkit.spec
@@ -20,7 +20,7 @@ software.Get Started * See the docsAuthor James Gardner <>_Changes20111210 *
 Changed aptcacherng to run on port 3142 to avoid a potential conflict with
 supervisor20111208 * Separated key generation from install of buildkitaptrepo.
 * Made repo and key base directory settings options of the buildkit repo
-command so that ...
+command so that...
 
 %package -n     python2-%{pypi_name}
 Summary:        %{summary}
@@ -32,7 +32,7 @@ software.Get Started * See the docsAuthor James Gardner <>_Changes20111210 *
 Changed aptcacherng to run on port 3142 to avoid a potential conflict with
 supervisor20111208 * Separated key generation from install of buildkitaptrepo.
 * Made repo and key base directory settings options of the buildkit repo
-command so that ...
+command so that...
 
 
 %prep

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -25,7 +25,7 @@ documentation for Python projects (or other documents consisting of multiple
 reStructuredText sources), written by Georg Brandl. It was originally created
 for the new Python documentation, and has excellent facilities for Python
 project documentation, but C/C++ is supported as well, and more languages are
-Sphinx uses ...
+Sphinx uses...
 
 %package -n     python2-%{srcname}
 Summary:        %{summary}
@@ -49,7 +49,7 @@ documentation for Python projects (or other documents consisting of multiple
 reStructuredText sources), written by Georg Brandl. It was originally created
 for the new Python documentation, and has excellent facilities for Python
 project documentation, but C/C++ is supported as well, and more languages are
-Sphinx uses ...
+Sphinx uses...
 
 %package -n     python3-%{srcname}
 Summary:        %{summary}
@@ -73,7 +73,7 @@ documentation for Python projects (or other documents consisting of multiple
 reStructuredText sources), written by Georg Brandl. It was originally created
 for the new Python documentation, and has excellent facilities for Python
 project documentation, but C/C++ is supported as well, and more languages are
-Sphinx uses ...
+Sphinx uses...
 
 %package -n python-%{srcname}-doc
 Summary:        Sphinx documentation

--- a/tests/test_extract_distribution.py
+++ b/tests/test_extract_distribution.py
@@ -1,6 +1,8 @@
 import pytest
 
-from command.extract_dist import to_list
+from flexmock import flexmock
+
+from command.extract_dist import to_list, extract_dist
 
 
 class TestExtractDistribution(object):
@@ -15,3 +17,16 @@ class TestExtractDistribution(object):
     ])
     def test_list(self, var, expected):
         assert to_list(var) == expected
+
+    @pytest.mark.parametrize(('metadata'), [
+        ({'foo': lambda: None}),
+        ({'foo': ['bar', lambda: None]}),
+    ])
+    def test_serializing_metadata_to_stdout_success(self, metadata, capsys):
+        flexmock(extract_dist).should_receive('__init__').and_return(None)
+        command = extract_dist()
+        command.metadata = metadata
+        command.stdout = True
+        command.run()
+        out, err = capsys.readouterr()
+        assert not err

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps = 


### PR DESCRIPTION
Use default serializer when sending extracted metadata to stdout to convert functions and other non serializable objects to string rather than raise an exception (fixes #97). Provide unit tests. 

The PR also includes:
* Fix for test failures after various dependencies updated (jinja, setuptools, pytest-runner)
Travis Ci Cron Job to identify these in the future?

* Run tests in Python 3.6 and recent dev version