### PR TITLE
Provide --sclize option

### DIFF
--- a/pyp2rpm.1
+++ b/pyp2rpm.1
@@ -59,8 +59,37 @@ Specify proxy in the form proxy.server:port.
 .B "\--venv / --no-venv \"
 Enable / disable metadata extraction from virtualenv.
 .TP
+\fB\-\-sclize\fR
+Convert tags and macro definitions to SCL\-style
+using `spec2scl` module. NOTE: SCL related options
+can be provided alongside this option.
+.TP
 .B "\-h , --help\"
 show this help message and exit.
+.SS "SCL related options:"
+.TP
+\fB\-\-no\-meta\-runtime\-dep\fR
+Don't add the runtime dependency on the scl
+runtime package.
+.TP
+\fB\-\-no\-meta\-buildtime\-dep\fR
+Don't add the buildtime dependency on the scl
+runtime package.
+.TP
+\fB\-\-skip\-functions\fR FUNCTIONS
+Comma separated list of transformer functions to
+skip.
+.TP
+\fB\-\-no\-deps\-convert\fR
+Don't convert dependency tags (mutually
+exclusive with \fB\-\-list\-file\fR).
+.TP
+\fB\-\-list\-file\fR FILE_NAME
+List of the packages/provides, that will be in
+the SCL (to convert Requires/BuildRequires
+properly). Lines in the file are in form of
+"pkg\-name %%{?custom_prefix}", where the prefix
+part is optional.
 
 
 .SH EXAMPLES

--- a/pyp2rpm.1
+++ b/pyp2rpm.1
@@ -2,13 +2,11 @@
 
 .SH NAME
 .B pyp2rpm
-Tool which convert a package from PyPI to RPM specfile or SRPM.
+Tool which converts a package from PyPI to RPM specfile or SRPM.
 
 .SH SYNOPSIS
-.B pyp2rpm
-[-h] [-v VERSION] [-d SAVE_DIR] [-r RPM_NAME] [-t TEMPLATE]
-[-o DISTRO] [-b BASE_PYTHON] [-p PYTHON_VERSION] [--srpm] [--proxy PROXY]
-.B PACKAGE
+.B mybin.py
+[\fI\,OPTIONS\/\fR] \fI\,PACKAGE\/\fR
 
 
 .SH ARGUMENTS
@@ -120,5 +118,4 @@ PYTHON
 MIT
 
 .SH AUTHOR
-Writen by Bohuslav "Slavek" Kabrda, Robert Kuska, Michal Cyprian
-
+Writen by Bohuslav "Slavek" Kabrda, Robert Kuska, Michal Cyprian, Iryna Shcherbina

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     tests_require=['pytest'],
     extras_require={
         'venv metadata': ['virtualenv-api'],
+        'sclize': ['spec2scl >= 1.1.4']
     },
     classifiers=['Development Status :: 4 - Beta',
                  'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,6 @@ deps =
     virtualenv
     scripttest
     click
+    spec2scl >= 1.1.4
 
 commands = python setup.py test --addopts -vv


### PR DESCRIPTION
Enable generating sclized spec files using spec2scl.
The following spec2scl options can be provided alongside:

- --no-meta-runtime-dep
- --no-meta-buildtime-dep
- --skip-functions
- --no-deps-convert
- --list-file

Issue #100 