### PR TITLE
Include extras require in metadata extraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
 - '3.6'
 - 'nightly'
 
+matrix:
+    allow_failures:
+        - python: 'nightly'
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/command/extract_dist.py
+++ b/command/extract_dist.py
@@ -11,7 +11,7 @@ class extract_dist(Command):
     class_metadata = None
 
     def __init__(self, *args, **kwargs):
-        """Metadata dictionary is created, all the metadata attributes, that were 
+        """Metadata dictionary is created, all the metadata attributes, that were
         not found are set to default empty values. Checks of data types are performed.
         """
         Command.__init__(self, *args, **kwargs)
@@ -21,6 +21,18 @@ class extract_dist(Command):
         for attr in ['setup_requires', 'tests_require', 'install_requires',
                      'packages', 'py_modules', 'scripts']:
             self.metadata[attr] = to_list(getattr(self.distribution, attr, []))
+
+        try:
+            for k, v in getattr(self.distribution, 'extras_require', {}).items():
+                if k in ['test, docs', 'doc', 'dev']:
+                    attr = 'setup_requires'
+                else:
+                    attr = 'install_requires'
+                self.metadata[attr] += to_list(v)
+        except (AttributeError, ValueError):
+            # extras require are skipped in case of wrong data format
+            # can't log here, because this file is executed in a subprocess
+            pass
 
         for attr in ['url', 'long_description', 'description', 'license']:
             self.metadata[attr] = to_str(getattr(self.distribution.metadata, attr, None))

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -460,7 +460,6 @@ class WheelMetadataExtractor(LocalMetadataExtractor):
 
     def get_requires(self, requires_types):
         "Extracts requires of given types from metadata file, filter windows specific requires"
-        # TODO extras?
         if not isinstance(requires_types, list):
             requires_types = list(requires_types)
         extracted_requires = []

--- a/tests/test_data/python-Jinja2.spec
+++ b/tests/test_data/python-Jinja2.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.1.2
+# Created by pyp2rpm-3.2.2
 %global pypi_name Jinja2
 
 Name:           python-%{pypi_name}
@@ -31,6 +31,7 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{pypi_name}}
  
 Requires:       python-MarkupSafe
+Requires:       python-Babel >= 0.8
 %description -n python2-%{pypi_name}
 Jinja2 is a template engine written in pure Python. It provides a Django_
 inspired nonXML syntax but supports inline expressions and an optional
@@ -44,6 +45,7 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{pypi_name}}
  
 Requires:       python3-MarkupSafe
+Requires:       python3-Babel >= 0.8
 %description -n python3-%{pypi_name}
 Jinja2 is a template engine written in pure Python. It provides a Django_
 inspired nonXML syntax but supports inline expressions and an optional
@@ -94,5 +96,5 @@ rm -rf html/.{doctrees,buildinfo}
 %doc html 
 
 %changelog
-* Mon Aug 22 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Apr 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_base.spec
+++ b/tests/test_data/python-Jinja2_base.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.1.2
+# Created by pyp2rpm-3.2.2
 %global pypi_name Jinja2
 
 Name:           python-%{pypi_name}
@@ -28,6 +28,7 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{pypi_name}}
  
 Requires:       python3-MarkupSafe
+Requires:       python3-Babel >= 0.8
 %description -n python3-%{pypi_name}
 Jinja2 is a template engine written in pure Python. It provides a Django_
 inspired nonXML syntax but supports inline expressions and an optional
@@ -67,5 +68,5 @@ rm -rf html/.{doctrees,buildinfo}
 %doc html 
 
 %changelog
-* Mon Aug 22 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Apr 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel6.spec
+++ b/tests/test_data/python-Jinja2_epel6.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.1.2
+# Created by pyp2rpm-3.2.2
 %global pypi_name Jinja2
 
 Name:           python-%{pypi_name}
@@ -16,6 +16,7 @@ BuildRequires:  python-setuptools
 BuildRequires:  python-sphinx
  
 Requires:       python-MarkupSafe
+Requires:       python-Babel >= 0.8
 
 %description
 Jinja2 is a template engine written in pure Python. It provides a Django_
@@ -50,5 +51,5 @@ rm -rf html/.{doctrees,buildinfo}
 
 
 %changelog
-* Mon Aug 22 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Apr 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel7.spec
+++ b/tests/test_data/python-Jinja2_epel7.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.1.2
+# Created by pyp2rpm-3.2.2
 %global pypi_name Jinja2
 
 Name:           python-%{pypi_name}
@@ -30,6 +30,7 @@ user.username }}</a></li> {%...
 Summary:        A small but fast and easy to use stand-alone template engine written in pure python
  
 Requires:       python-MarkupSafe
+Requires:       python-Babel >= 0.8
 %description -n python2-%{pypi_name}
 Jinja2 is a template engine written in pure Python. It provides a Django_
 inspired nonXML syntax but supports inline expressions and an optional
@@ -42,6 +43,7 @@ user.username }}</a></li> {%...
 Summary:        A small but fast and easy to use stand-alone template engine written in pure python
  
 Requires:       python%{python3_pkgversion}-MarkupSafe
+Requires:       python%{python3_pkgversion}-Babel >= 0.8
 %description -n python%{python3_pkgversion}-%{pypi_name}
 Jinja2 is a template engine written in pure Python. It provides a Django_
 inspired nonXML syntax but supports inline expressions and an optional
@@ -90,5 +92,5 @@ rm -rf html/.{doctrees,buildinfo}
 %doc html 
 
 %changelog
-* Mon Aug 22 2016 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Apr 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-buildkit.spec
+++ b/tests/test_data/python-buildkit.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.1.3
+# Created by pyp2rpm-3.2.2
 %global pypi_name buildkit
 
 Name:           python-%{pypi_name}
@@ -25,7 +25,8 @@ command so that...
 %package -n     python2-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{pypi_name}}
-
+ 
+Requires:       python-Sphinx = 0.6.7
 %description -n python2-%{pypi_name}
 ++++++++.. contents :: Summary Cloud infrastructure and .deb file management
 software.Get Started * See the docsAuthor James Gardner <>_Changes20111210 *
@@ -54,5 +55,5 @@ rm -rf %{pypi_name}.egg-info
 %{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
-* Thu Sep 22 2016 Michal Cyprian <mcyprian@redhat.com> - 0.2.2-1
+* Tue Apr 11 2017 Michal Cyprian <mcyprian@redhat.com> - 0.2.2-1
 - Initial package.

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.2.1
+# Created by pyp2rpm-3.2.2
 %global pypi_name Sphinx
 %global srcname sphinx
 
@@ -36,12 +36,19 @@ Requires:       python-Jinja2 >= 2.3
 Requires:       python-Pygments >= 2.0
 Requires:       python-docutils >= 0.11
 Requires:       python-snowballstemmer >= 1.1
-Conflicts:      python-babel = 2.0
 Requires:       python-babel >= 1.3
+Conflicts:      python-babel = 2.0
 Requires:       python-alabaster < 0.8
 Requires:       python-alabaster >= 0.7
 Requires:       python-imagesize
 Requires:       python-requests
+Requires:       python-nose
+Requires:       python-mock
+Requires:       python-simplejson
+Requires:       python-html5lib
+Requires:       python-sqlalchemy >= 0.9
+Requires:       python-whoosh >= 2.0
+Requires:       python-colorama >= 0.3.5
 Requires:       python-setuptools
 %description -n python2-%{srcname}
 Sphinx is a tool that makes it easy to create intelligent and beautiful
@@ -60,12 +67,19 @@ Requires:       python3-Jinja2 >= 2.3
 Requires:       python3-Pygments >= 2.0
 Requires:       python3-docutils >= 0.11
 Requires:       python3-snowballstemmer >= 1.1
-Conflicts:      python3-babel = 2.0
 Requires:       python3-babel >= 1.3
+Conflicts:      python3-babel = 2.0
 Requires:       python3-alabaster < 0.8
 Requires:       python3-alabaster >= 0.7
 Requires:       python3-imagesize
 Requires:       python3-requests
+Requires:       python3-nose
+Requires:       python3-mock
+Requires:       python3-simplejson
+Requires:       python3-html5lib
+Requires:       python3-sqlalchemy >= 0.9
+Requires:       python3-whoosh >= 2.0
+Requires:       python3-colorama >= 0.3.5
 Requires:       python3-setuptools
 %description -n python3-%{srcname}
 Sphinx is a tool that makes it easy to create intelligent and beautiful
@@ -153,5 +167,5 @@ ln -s %{_bindir}/sphinx-autogen-%{python2_version} %{buildroot}/%{_bindir}/sphin
 %doc html 
 
 %changelog
-* Fri Nov 25 2016 Iryna Shcherbina <ishcherb@redhat.com> - 1.4.9-1
+* Tue Apr 11 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
 - Initial package.


### PR DESCRIPTION
Including extras require listed in setup.py in build requires can prevent tests of doc building failures in some cases. PR also contains updated integration tests data.