### PR TITLE
fix pld template

### DIFF
--- a/pyp2rpm/templates/pld.spec
+++ b/pyp2rpm/templates/pld.spec
@@ -17,7 +17,7 @@
 
 {# Foreach all python_versions, prints caller content.
    Content is surrounded by conditionals if use_with is True #}
-{%- macro foreach_python_versions(caller, use_with=True, v='') %}
+{%- macro foreach_python_versions(use_with=True, v='') %}
 {%- for pv in [data.base_python_version] + data.python_versions %}
 {%- if use_with %}
 %if %{with python{{ pv }}}


### PR DESCRIPTION
with jinja2-2.9.5:
jinja2.exceptions.TemplateAssertionError: When defining macros or call blocks the special "caller" argument must be omitted or be given a default.