### PR TITLE
Empty Source0 tag

### DIFF
--- a/pyp2rpm/archive.py
+++ b/pyp2rpm/archive.py
@@ -77,7 +77,8 @@ class Archive(object):
 
     def __init__(self, local_file):
         self.file = local_file
-        self.name, self.suffix = os.path.splitext(local_file)
+        self.name = os.path.basename(local_file)
+        self.suffix = os.path.splitext(local_file)[1]
         self.handle = None
         ZipInfo.name = ZipInfo.filename
 

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -217,12 +217,14 @@ class Convertor(object):
 
     @property
     def client(self):
-        """Returns the XMLRPC client for PyPI. Always returns the same instance.
+        """XMLRPC client for PyPI. Always returns the same instance.
+
+        If the package is provided as a path to compressed source file,
+        PyPI will not be used and the client will not be instantiated.
 
         Returns:
-            XMLRPC client for PyPI.
+            XMLRPC client for PyPI or None.
         """
-        # cannot use "if self._client"...
         if self.proxy:
             proxyhandler = urllib.ProxyHandler({"http": self.proxy})
             opener = urllib.build_opener(proxyhandler)

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -36,7 +36,7 @@ def pypi_metadata_extension(extraction_fce):
         data = extraction_fce(self)
         if client is None:
             logger.warning("Client is None, it was probably disabled")
-            data.update_attr('url', self.archive.name)
+            data.update_attr('source0', self.archive.name)
             return data
         try:
             release_data = client.release_data(self.name, self.version)
@@ -48,7 +48,7 @@ def pypi_metadata_extension(extraction_fce):
             url, md5_digest = get_url(client, self.name, self.version)
         except exc.MissingUrlException:
             url, md5_digest = ('FAILED TO EXTRACT FROM PYPI', 'FAILED TO EXTRACT FROM PYPI')
-        data_dict = {'url': url, 'md5': md5_digest}
+        data_dict = {'source0': url, 'md5': md5_digest}
 
         for data_field in settings.PYPI_USABLE_DATA:
             data_dict[data_field] = release_data.get(data_field, '')

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -36,6 +36,7 @@ def pypi_metadata_extension(extraction_fce):
         data = extraction_fce(self)
         if client is None:
             logger.warning("Client is None, it was probably disabled")
+            data.update_attr('url', self.archive.name)
             return data
         try:
             release_data = client.release_data(self.name, self.version)

--- a/pyp2rpm/package_data.py
+++ b/pyp2rpm/package_data.py
@@ -23,7 +23,7 @@ class PackageData(object):
 
     """A simple object that carries data about a package."""
 
-    def __init__(self, local_file, name, pkg_name, version, md5='', url='', srcname=None):
+    def __init__(self, local_file, name, pkg_name, version, md5='', source0='', srcname=None):
         object.__setattr__(self, 'data', {})
         self.data['local_file'] = local_file
         self.data['name'] = name
@@ -32,7 +32,7 @@ class PackageData(object):
         self.data['version'] = version
         self.data['python_versions'] = []
         self.data['md5'] = md5
-        self.data['url'] = url
+        self.data['source0'] = source0
         self.data['sphinx_dir'] = None
 
     def __getattr__(self, name):

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -15,7 +15,7 @@ Summary:        {{ data.summary }}
 
 License:        {{ data.license }}
 URL:            {{ data.home_page }}
-Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
 
 {%- if not data.has_extension %}
 BuildArch:      noarch

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -12,7 +12,7 @@ Summary:        {{ data.summary }}
 
 License:        {{ data.license }}
 URL:            {{ data.home_page }}
-Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
 
 {%- if not data.has_extension %}
 BuildArch:      noarch

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -12,7 +12,7 @@ Summary:        {{ data.summary }}
 
 License:        {{ data.license }}
 URL:            {{ data.home_page }}
-Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
 
 {%- if not data.has_extension %}
 BuildArch:      noarch

--- a/pyp2rpm/templates/fedora_subdirs.spec
+++ b/pyp2rpm/templates/fedora_subdirs.spec
@@ -15,7 +15,7 @@ Summary:        {{ data.summary }}
 
 License:        {{ data.license }}
 URL:            {{ data.home_page }}
-Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
 
 {%- if not data.has_extension %}
 BuildArch:      noarch

--- a/pyp2rpm/templates/mageia.spec
+++ b/pyp2rpm/templates/mageia.spec
@@ -17,7 +17,7 @@ Summary:        {{ data.summary }}
 
 License:        {{ data.license }}
 URL:            {{ data.home_page }}
-Source0:        {{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
 
 {%- if not data.has_extension %}
 BuildArch:      noarch

--- a/pyp2rpm/templates/pld.spec
+++ b/pyp2rpm/templates/pld.spec
@@ -49,7 +49,7 @@ Version:	{{ data.version }}
 Release:	0.1
 License:	{{ data.license }}
 Group:		Libraries/Python
-Source0:	{{ data.url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:	{{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
 # Source0-md5:	-
 URL:		{{ data.home_page }}
 BuildRequires:	rpm-pythonprov

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -228,7 +228,7 @@ class TestPyPIMetadataExtension(object):
          'OSXInterpreters: Python versions 2.4 through to 3.2, Jython 2.5.1 '
          'and PyPy1.6/1.7Bugs and issues: page: (c) Holger Krekel and others, 20042012'),
         ('md5', '9a7a2f6943baba054cf1c28e05a9198e'),
-        ('url',  'https://files.pythonhosted.org/packages/source/p/pytest/restsh-0.1.tar.gz'),
+        ('source0', 'https://files.pythonhosted.org/packages/source/p/pytest/restsh-0.1.tar.gz'),
         ('license', 'MIT license'),
         ('summary', 'py.test: simple powerful testing with Python')
     ])
@@ -266,6 +266,7 @@ class TestSetupPyMetadataExtractor(object):
         (0, 'doc_files', ['README.rst']),
         (0, 'doc_license', ['LICENSE']),
         (0, 'sphinx_dir', None),
+        (0, 'source0', 'plumbum-0.9.0.tar.gz'),
         (1, 'runtime_deps', [['Requires', 'python-py', '>=', '1.4.7.dev2'],
                              ['Requires', 'python-setuptools']]),
         (1, 'build_deps', [['BuildRequires', 'python2-devel'],
@@ -284,6 +285,7 @@ class TestSetupPyMetadataExtractor(object):
         (1, 'doc_files', ['README.txt']),
         (1, 'doc_license', ['LICENSE']),
         (1, 'sphinx_dir', 'doc'),
+        (1, 'source0', 'pytest-2.2.3.zip'),
         (2, 'py_modules', set(['simpleeval'])),
         (3, 'runtime_deps', [['Requires', 'python-coverage']]),
         (3, 'python_versions', ['3']),


### PR DESCRIPTION
- [x] use source file name for `Source0` tag if the package is provided as a path to compressed source file
- [x] rename `PackageData.url` attribute to `source0` as it is used only for `Source0` tag, and given the change in this PR it is not always a URL.

Fixes #118.