### PR TITLE
Add name convertor based on automatic provides

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,57 @@ All of the options are (print this by running pyp2rpm -h):
 
     Convert PyPI package to RPM specfile or SRPM.
 
-    arguments:
-      PACKAGE             Provide PyPI name of the package or path to compressed
-                          source file.
+  Arguments:
+    PACKAGE             Provide PyPI name of the package or path to compressed source file.
 
-    optional arguments:
-      -h, --help          show this help message and exit
-      -v VERSION          Version of the package to download (ignored for local files).
-      -d SAVE_DIR         Where to save the package file (default: "~/rpmbuild")
-      -r RPM_NAME         Name of rpm package (overrides calculated name)
-      -t TEMPLATE         Template file (jinja2 format) to render (default: "fedora").
-                          Search order is 1) filesystem, 2) default templates.
-      -o DISTRO           Default distro whose conversion rules to use
-                          (default: "fedora"). Default templates have their rules
-                          associated and ignore this.
-      -b BASE_PYTHON      Base Python version to package for (default: "2").
-      -p PYTHON_VERSIONS  Additional Python versions to include in the specfile
-                          (e.g -p3 for %{?with_python3}). Can be specified multiple times
-                          (default: "3"). Specify additional version or use -b
-                          explicitly to disable default.
-      --srpm              When used pyp2rpm will produce srpm instead of printing
-                          specfile into stdout.
-      --proxy PROXY       Specify proxy in the form proxy.server:port.
-      --venv / --no-venv  Enable / disable metadata extraction from virtualenv
+  Options:
+    -t TEMPLATE             Template file (jinja2 format) to render (default:
+                            "fedora").Search order is 1) filesystem, 2) default
+                            templates.
+    -o [fedora|mageia|pld]  Default distro whose conversion rules to use
+                            (default:"fedora").Default templates have their
+                            rules associated and ignore this.
+    -b BASE_PYTHON          Base Python version to package for (default: "2").
+    -p PYTHON_VERSIONS      Additional Python versions to include in the
+                            specfile (e.g -p3 for %{?with_python3}).Can be
+                            specified multiple times (default: "3"). Specify
+                            additional version or use -b explicitly to disable
+                            default.
+    -s                      Spec file ~/rpmbuild/SPECS/python-package_name.spec
+                            will be created (default: prints spec file to
+                            stdout).
+    --srpm                  When used pyp2rpm will produce srpm instead of
+                            printing specfile into stdout.
+    --proxy PROXY           Specify proxy in the form proxy.server:port.
+    -r RPM_NAME             Name of rpm package (overrides calculated name).
+    -d SAVE_PATH            Specify where to save package file, specfile and
+                            generated SRPM (default: "/home/mcyprian/rpmbuild").
+    -v VERSION              Version of the package to download (ignored for
+                            local files).
+    --venv / --no-venv      Enable / disable metadata extraction from virtualenv
+                            (default: enabled).
+    --autonc / --no-autonc  Enable / disable using automatic provides with a
+                            standardized name in dependencies declaration
+                            (default: disabled).
+    --sclize                Convert tags and macro definitions to SCL-style
+                            using `spec2scl` module. NOTE: SCL related options
+                            can be provided alongside this option.
+    -h, --help              Show this message and exit.
 
+  SCL related options:
+    --no-meta-runtime-dep       Don't add the runtime dependency on the scl
+                                runtime package.
+    --no-meta-buildtime-dep     Don't add the buildtime dependency on the scl
+                                runtime package.
+    --skip-functions FUNCTIONS  Comma separated list of transformer functions to
+                                skip.
+    --no-deps-convert           Don't convert dependency tags (mutually
+                                exclusive with --list-file).
+    --list-file FILE_NAME       List of the packages/provides, that will be in
+                                the SCL (to convert Requires/BuildRequires
+                                properly). Lines in the file are in form of
+                                "pkg-name %%{?custom_prefix}", where the prefix
+                                part is optional.
 
 
 To run the unit tests, cd into the checked out directory and run:

--- a/pyp2rpm.1
+++ b/pyp2rpm.1
@@ -54,6 +54,9 @@ Version of the package to download (ignored for local files).
 .B "\--venv / --no-venv \"
 Enable / disable metadata extraction from virtualenv.
 .TP
+.B "\--autonc/ --no-autonc\"
+Enable / disable using automatic provides with a standardized name in dependencies declaration.
+.TP
 \fB\-\-sclize\fR
 Convert tags and macro definitions to SCL\-style
 using `spec2scl` module. NOTE: SCL related options

--- a/pyp2rpm/bin.py
+++ b/pyp2rpm/bin.py
@@ -117,6 +117,10 @@ class SclizeOption(click.Option):
 @click.option('--venv / --no-venv',
               default=True,
               help='Enable / disable metadata extraction from virtualenv (default: enabled).')
+@click.option('--autonc/ --no-autonc',
+              default=False,
+              help='Enable / disable using automatic provides with a standardized '
+              'name in dependencies declaration (default: disabled).')
 @click.option('--sclize',
               help='Convert tags and macro definitions to SCL-style using `spec2scl` module.'
                    ' NOTE: SCL related options can be provided alongside this option.',
@@ -143,7 +147,7 @@ class SclizeOption(click.Option):
               default=None,
               metavar='FILE_NAME')
 @click.argument('package', nargs=1)
-def main(package, v, d, s, r, proxy, srpm, p, b, o, t, venv, sclize, **scl_kwargs):
+def main(package, v, d, s, r, proxy, srpm, p, b, o, t, venv, autonc, sclize, **scl_kwargs):
     """Convert PyPI package to RPM specfile or SRPM.
 
     \b
@@ -171,7 +175,8 @@ def main(package, v, d, s, r, proxy, srpm, p, b, o, t, venv, sclize, **scl_kwarg
                           python_versions=p,
                           rpm_name=r,
                           proxy=proxy,
-                          venv=venv)
+                          venv=venv,
+                          autonc=autonc)
 
     logger.debug('Convertor: {0} created. Trying to convert.'.format(convertor))
     converted = convertor.convert()

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -449,7 +449,8 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
         if sphinx_dir:
             archive_data['sphinx_dir'] = "/".join(sphinx_dir.split("/")[1:])
             archive_data['build_deps'].append(
-                ['BuildRequires', 'python-sphinx'])
+                ['BuildRequires', self.name_convertor.rpm_name(
+                    "sphinx", settings.DEFAULT_PYTHON_VERSION)])
 
         return archive_data
 

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -37,9 +37,9 @@ Summary:        {{ data.summary }}
 {{ data.description|truncate(400)|wordwrap }}
 {%- endcall %}
 {%- if data.sphinx_dir %}
-%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
+%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(None, True) }}-doc
 Summary:        {{ data.name }} documentation
-%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(None, True) }}-doc
 Documentation for {{ data.name }}
 {%- endif %}
 

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -33,9 +33,9 @@ Summary:        %{summary}
 {{ data.description|truncate(400)|wordwrap }}
 {% endfor -%}
 {%- if data.sphinx_dir %}
-%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
+%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(None, True) }}-doc
 Summary:        {{ data.name }} documentation
-%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(None, True) }}-doc
 Documentation for {{ data.name }}
 {%- endif %}
 
@@ -120,7 +120,7 @@ ln -s %{_bindir}/{{ script|script_name_for_python_version(pv, True) }} %{buildro
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}
-%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
+%files -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(None, True) }}-doc
 %doc html
 {%- if data.doc_license %}
 %license {{data.doc_license|join(' ')}}

--- a/pyp2rpm/templates/fedora_subdirs.spec
+++ b/pyp2rpm/templates/fedora_subdirs.spec
@@ -37,9 +37,9 @@ Summary:        {{ data.summary }}
 {{ data.description|truncate(400)|wordwrap }}
 {%- endcall %}
 {%- if data.sphinx_dir %}
-%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
+%package -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(None, True) }}-doc
 Summary:        {{ data.name }} documentation
-%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(pv, True) }}-doc
+%description -n {{ data.pkg_name|macroed_pkg_name(data.srcname)|name_for_python_version(None, True) }}-doc
 Documentation for {{ data.name }}
 {%- endif %}
 

--- a/tests/test_data/python-Jinja2_autonc.spec
+++ b/tests/test_data/python-Jinja2_autonc.spec
@@ -1,0 +1,102 @@
+# Created by pyp2rpm-3.2.2
+%global pypi_name Jinja2
+
+Name:           %{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+ 
+BuildRequires:  python2-devel
+BuildRequires:  python2dist(setuptools)
+BuildRequires:  python2dist(sphinx)
+ 
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(sphinx)
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+ 
+Requires:       python2dist(markupsafe)
+Requires:       python2dist(babel) >= 0.8
+%description -n python2-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+ 
+Requires:       python3dist(markupsafe)
+Requires:       python3dist(babel) >= 0.8
+%description -n python3-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n %{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n %{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%py3_build
+# generate html docs 
+sphinx-build docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install.
+%py3_install
+
+%py2_install
+
+
+%files -n python2-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n python3-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n %{pypi_name}-doc
+%doc html
+%license docs/_themes/LICENSE LICENSE
+
+%changelog
+* Thu Jul 20 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,6 +23,7 @@ class TestSpec(object):
         ('Jinja2', '-v2.8 -b3', 'python-Jinja2_base.spec'),
         ('Jinja2', '-v2.8 -t epel7', 'python-Jinja2_epel7.spec'),
         ('Jinja2', '-v2.8 -t epel6', 'python-Jinja2_epel6.spec'),
+        ('Jinja2', '-v2.8 --autonc', 'python-Jinja2_autonc.spec'),
         ('buildkit', '-v0.2.2 -b2', 'python-buildkit.spec'),
         ('StructArray', '-v0.1 -b2', 'python-StructArray.spec'),
         ('Sphinx', '-v1.5 -r python-sphinx', 'python-sphinx.spec'),


### PR DESCRIPTION
This convertor uses standardized name format of the dependencies based on virtual Provides created during RPM build: https://fedoraproject.org/wiki/Changes/Automatic_Provides_for_Python_RPM_Packages

There is a command line option to enable/disable this convertor, it is disabled by default at this moment. It can be used by default for Fedora after F27 mass rebuild.

[Here](https://copr.fedorainfracloud.org/coprs/mcyprian/pypi_provides_test/builds/) is the test build of spec file listing dependencies in the canonical format.