### PR TITLE
Dependencies with versioned prefix

### DIFF
--- a/pyp2rpm/templates/macros.spec
+++ b/pyp2rpm/templates/macros.spec
@@ -1,7 +1,6 @@
 {# prints a single dependency for a specific python version #}
 {%- macro one_dep(dep, python_version, epel=False) %}
-{{ dep[0] }}:{{ ' ' * (15 - dep[0]|length) }}{{ dep[1]|name_for_python_version(python_version,
-False, epel) }}{% if dep[2] is defined %} {{ dep[2] }} {{ dep[3] }}{% endif %}
+{{ dep[0] }}:{{ ' ' * (15 - dep[0]|length) }}{{ dep[1]|name_for_python_version(python_version, True, epel) }}{% if dep[2] is defined %} {{ dep[2] }} {{ dep[3] }}{% endif %}
 {%- endmacro %}
 
 {# Prints given deps (runtime or buildtime for given python_version,

--- a/tests/test_data/python-Jinja2.spec
+++ b/tests/test_data/python-Jinja2.spec
@@ -12,8 +12,8 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
-BuildRequires:  python-sphinx
+BuildRequires:  python2-setuptools
+BuildRequires:  python2-sphinx
  
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -30,8 +30,8 @@ user.username }}</a></li>...
 Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{pypi_name}}
  
-Requires:       python-MarkupSafe
-Requires:       python-Babel >= 0.8
+Requires:       python2-MarkupSafe
+Requires:       python2-Babel >= 0.8
 %description -n python2-%{pypi_name}
 Jinja2 is a template engine written in pure Python. It provides a Django_
 inspired non-XML syntax but supports inline expressions and an optional
@@ -97,5 +97,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon May 22 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Fri Jul 07 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_base.spec
+++ b/tests/test_data/python-Jinja2_base.spec
@@ -69,5 +69,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon May 22 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Fri Jul 07 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel6.spec
+++ b/tests/test_data/python-Jinja2_epel6.spec
@@ -12,11 +12,11 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
-BuildRequires:  python-sphinx
+BuildRequires:  python2-setuptools
+BuildRequires:  python2-sphinx
  
-Requires:       python-MarkupSafe
-Requires:       python-Babel >= 0.8
+Requires:       python2-MarkupSafe
+Requires:       python2-Babel >= 0.8
 
 %description
 Jinja2 is a template engine written in pure Python. It provides a Django_
@@ -58,5 +58,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon May 22 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Fri Jul 07 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel7.spec
+++ b/tests/test_data/python-Jinja2_epel7.spec
@@ -12,8 +12,8 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
-BuildRequires:  python-sphinx
+BuildRequires:  python2-setuptools
+BuildRequires:  python2-sphinx
  
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
@@ -29,8 +29,8 @@ user.username }}</a></li>...
 %package -n     python2-%{pypi_name}
 Summary:        A small but fast and easy to use stand-alone template engine written in pure python
  
-Requires:       python-MarkupSafe
-Requires:       python-Babel >= 0.8
+Requires:       python2-MarkupSafe
+Requires:       python2-Babel >= 0.8
 %description -n python2-%{pypi_name}
 Jinja2 is a template engine written in pure Python. It provides a Django_
 inspired non-XML syntax but supports inline expressions and an optional
@@ -93,5 +93,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon May 22 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Fri Jul 07 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-StructArray.spec
+++ b/tests/test_data/python-StructArray.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.2.1
+# Created by pyp2rpm-3.2.2
 %global pypi_name StructArray
 
 Name:           python-%{pypi_name}
@@ -11,7 +11,7 @@ URL:            http://matthewmarshall.org/projects/structarray/
 Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
  
 BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
+BuildRequires:  python2-setuptools
 
 %description
  StructArray StructArray allows you to perform fast arithmetic operations on
@@ -52,5 +52,5 @@ rm -rf %{pypi_name}.egg-info
 %{python2_sitearch}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
-* Tue Dec 06 2016 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
+* Fri Jul 07 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
 - Initial package.

--- a/tests/test_data/python-buildkit.spec
+++ b/tests/test_data/python-buildkit.spec
@@ -12,7 +12,7 @@ Source0:        https://files.pythonhosted.org/packages/source/b/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
+BuildRequires:  python2-setuptools
 
 %description
 ++++++++.. contents :: Summary Cloud infrastructure and .deb file management
@@ -26,7 +26,7 @@ repo...
 Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{pypi_name}}
  
-Requires:       python-Sphinx = 0.6.7
+Requires:       python2-Sphinx = 0.6.7
 %description -n python2-%{pypi_name}
 ++++++++.. contents :: Summary Cloud infrastructure and .deb file management
 software.Get Started * See the docsAuthor James Gardner <>_Changes--2011-12-10
@@ -55,5 +55,5 @@ rm -rf %{pypi_name}.egg-info
 %{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
-* Tue Apr 18 2017 Michal Cyprian <mcyprian@redhat.com> - 0.2.2-1
+* Fri Jul 07 2017 Michal Cyprian <mcyprian@redhat.com> - 0.2.2-1
 - Initial package.

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -13,8 +13,8 @@ Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
-BuildRequires:  python-sphinx
+BuildRequires:  python2-setuptools
+BuildRequires:  python2-sphinx
  
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -31,25 +31,25 @@ Sphinx uses...
 Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{srcname}}
  
-Requires:       python-six >= 1.5
-Requires:       python-Jinja2 >= 2.3
-Requires:       python-Pygments >= 2.0
-Requires:       python-docutils >= 0.11
-Requires:       python-snowballstemmer >= 1.1
-Conflicts:      python-babel = 2.0
-Requires:       python-babel >= 1.3
-Requires:       python-alabaster < 0.8
-Requires:       python-alabaster >= 0.7
-Requires:       python-imagesize
-Requires:       python-requests
-Requires:       python-nose
-Requires:       python-mock
-Requires:       python-simplejson
-Requires:       python-html5lib
-Requires:       python-sqlalchemy >= 0.9
-Requires:       python-whoosh >= 2.0
-Requires:       python-colorama >= 0.3.5
-Requires:       python-setuptools
+Requires:       python2-six >= 1.5
+Requires:       python2-Jinja2 >= 2.3
+Requires:       python2-Pygments >= 2.0
+Requires:       python2-docutils >= 0.11
+Requires:       python2-snowballstemmer >= 1.1
+Requires:       python2-babel >= 1.3
+Conflicts:      python2-babel = 2.0
+Requires:       python2-alabaster >= 0.7
+Requires:       python2-alabaster < 0.8
+Requires:       python2-imagesize
+Requires:       python2-requests
+Requires:       python2-sqlalchemy >= 0.9
+Requires:       python2-whoosh >= 2.0
+Requires:       python2-colorama >= 0.3.5
+Requires:       python2-nose
+Requires:       python2-mock
+Requires:       python2-simplejson
+Requires:       python2-html5lib
+Requires:       python2-setuptools
 %description -n python2-%{srcname}
 Sphinx is a tool that makes it easy to create intelligent and beautiful
 documentation for Python projects (or other documents consisting of multiple
@@ -67,19 +67,19 @@ Requires:       python3-Jinja2 >= 2.3
 Requires:       python3-Pygments >= 2.0
 Requires:       python3-docutils >= 0.11
 Requires:       python3-snowballstemmer >= 1.1
-Conflicts:      python3-babel = 2.0
 Requires:       python3-babel >= 1.3
-Requires:       python3-alabaster < 0.8
+Conflicts:      python3-babel = 2.0
 Requires:       python3-alabaster >= 0.7
+Requires:       python3-alabaster < 0.8
 Requires:       python3-imagesize
 Requires:       python3-requests
+Requires:       python3-sqlalchemy >= 0.9
+Requires:       python3-whoosh >= 2.0
+Requires:       python3-colorama >= 0.3.5
 Requires:       python3-nose
 Requires:       python3-mock
 Requires:       python3-simplejson
 Requires:       python3-html5lib
-Requires:       python3-sqlalchemy >= 0.9
-Requires:       python3-whoosh >= 2.0
-Requires:       python3-colorama >= 0.3.5
 Requires:       python3-setuptools
 %description -n python3-%{srcname}
 Sphinx is a tool that makes it easy to create intelligent and beautiful
@@ -111,55 +111,55 @@ rm -rf html/.{doctrees,buildinfo}
 # Must do the subpackages' install first because the scripts in /usr/bin are
 # overwritten with every setup.py install.
 %py3_install
+cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-%{python3_version}
+ln -s %{_bindir}/sphinx-autogen-%{python3_version} %{buildroot}/%{_bindir}/sphinx-autogen-3
+cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-%{python3_version}
+ln -s %{_bindir}/sphinx-apidoc-%{python3_version} %{buildroot}/%{_bindir}/sphinx-apidoc-3
 cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-%{python3_version}
 ln -s %{_bindir}/sphinx-build-%{python3_version} %{buildroot}/%{_bindir}/sphinx-build-3
 cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-%{python3_version}
 ln -s %{_bindir}/sphinx-quickstart-%{python3_version} %{buildroot}/%{_bindir}/sphinx-quickstart-3
-cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-%{python3_version}
-ln -s %{_bindir}/sphinx-apidoc-%{python3_version} %{buildroot}/%{_bindir}/sphinx-apidoc-3
-cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-%{python3_version}
-ln -s %{_bindir}/sphinx-autogen-%{python3_version} %{buildroot}/%{_bindir}/sphinx-autogen-3
 
 %py2_install
+cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-%{python2_version}
+ln -s %{_bindir}/sphinx-autogen-%{python2_version} %{buildroot}/%{_bindir}/sphinx-autogen-2
+cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-%{python2_version}
+ln -s %{_bindir}/sphinx-apidoc-%{python2_version} %{buildroot}/%{_bindir}/sphinx-apidoc-2
 cp %{buildroot}/%{_bindir}/sphinx-build %{buildroot}/%{_bindir}/sphinx-build-%{python2_version}
 ln -s %{_bindir}/sphinx-build-%{python2_version} %{buildroot}/%{_bindir}/sphinx-build-2
 cp %{buildroot}/%{_bindir}/sphinx-quickstart %{buildroot}/%{_bindir}/sphinx-quickstart-%{python2_version}
 ln -s %{_bindir}/sphinx-quickstart-%{python2_version} %{buildroot}/%{_bindir}/sphinx-quickstart-2
-cp %{buildroot}/%{_bindir}/sphinx-apidoc %{buildroot}/%{_bindir}/sphinx-apidoc-%{python2_version}
-ln -s %{_bindir}/sphinx-apidoc-%{python2_version} %{buildroot}/%{_bindir}/sphinx-apidoc-2
-cp %{buildroot}/%{_bindir}/sphinx-autogen %{buildroot}/%{_bindir}/sphinx-autogen-%{python2_version}
-ln -s %{_bindir}/sphinx-autogen-%{python2_version} %{buildroot}/%{_bindir}/sphinx-autogen-2
 
 
 %files -n python2-%{srcname}
 %license LICENSE
 %doc README.rst
+%{_bindir}/sphinx-autogen
+%{_bindir}/sphinx-autogen-2
+%{_bindir}/sphinx-autogen-%{python2_version}
+%{_bindir}/sphinx-apidoc
+%{_bindir}/sphinx-apidoc-2
+%{_bindir}/sphinx-apidoc-%{python2_version}
 %{_bindir}/sphinx-build
 %{_bindir}/sphinx-build-2
 %{_bindir}/sphinx-build-%{python2_version}
 %{_bindir}/sphinx-quickstart
 %{_bindir}/sphinx-quickstart-2
 %{_bindir}/sphinx-quickstart-%{python2_version}
-%{_bindir}/sphinx-apidoc
-%{_bindir}/sphinx-apidoc-2
-%{_bindir}/sphinx-apidoc-%{python2_version}
-%{_bindir}/sphinx-autogen
-%{_bindir}/sphinx-autogen-2
-%{_bindir}/sphinx-autogen-%{python2_version}
 %{python2_sitelib}/sphinx
 %{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %files -n python3-%{srcname}
 %license LICENSE
 %doc README.rst
+%{_bindir}/sphinx-autogen-3
+%{_bindir}/sphinx-autogen-%{python3_version}
+%{_bindir}/sphinx-apidoc-3
+%{_bindir}/sphinx-apidoc-%{python3_version}
 %{_bindir}/sphinx-build-3
 %{_bindir}/sphinx-build-%{python3_version}
 %{_bindir}/sphinx-quickstart-3
 %{_bindir}/sphinx-quickstart-%{python3_version}
-%{_bindir}/sphinx-apidoc-3
-%{_bindir}/sphinx-apidoc-%{python3_version}
-%{_bindir}/sphinx-autogen-3
-%{_bindir}/sphinx-autogen-%{python3_version}
 %{python3_sitelib}/sphinx
 %{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
@@ -168,5 +168,5 @@ ln -s %{_bindir}/sphinx-autogen-%{python2_version} %{buildroot}/%{_bindir}/sphin
 %license LICENSE
 
 %changelog
-* Mon May 22 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
+* Fri Jul 07 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
 - Initial package.


### PR DESCRIPTION
Convert names of dependencies using versioned prefix (python2-) to follow the latest Packaging Guidelines for Python. Fixes issue #128 