### PR TITLE
Use output of rpm --eval command, in case import of rpm module fails

### DIFF
--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -58,7 +58,7 @@ def license_from_trove(trove):
     """
     license = []
     for classifier in trove:
-        if 'License' in classifier != -1:
+        if 'License' in classifier:
             stripped = classifier.strip()
             # if taken from EGG-INFO, begins with Classifier:
             stripped = stripped[stripped.find('License'):]

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -1,9 +1,4 @@
-try:
-    import rpm
-    DEFAULT_PKG_SAVE_PATH = rpm.expandMacro("%{_topdir}")
-except ImportError:
-    import os
-    DEFAULT_PKG_SAVE_PATH = os.path.expanduser('~/rpmbuild')
+from pyp2rpm import utils
 
 DEFAULT_PYTHON_VERSION = '2'
 DEFAULT_ADDITIONAL_VERSION = '3'
@@ -11,6 +6,7 @@ DEFAULT_PKG_SOURCE = 'pypi'
 DEFAULT_METADATA_SOURCE = 'pypi'
 DEFAULT_TEMPLATE = 'fedora'
 DEFAULT_DISTRO = 'fedora'
+DEFAULT_PKG_SAVE_PATH = utils.get_default_save_path()
 KNOWN_DISTROS = ['fedora', 'mageia', 'pld']
 ARCHIVE_SUFFIXES = ['.tar', '.tgz', '.tar.gz', '.tar.bz2',
                     '.gz', '.bz2', '.xz', '.zip', '.egg', '.whl']
@@ -23,7 +19,6 @@ PYPI_URL = 'https://pypi.python.org/pypi'
 PYPI_USABLE_DATA = ['description', 'summary', 'license', 'home_page', 'requires']
 PYTHON_INTERPRETER = '/usr/bin/python'
 EXTRACT_DIST_COMMAND_ARGS = ['--quiet', '--command-packages', 'pyp2rpm.command', 'extract_dist']
-CONSOLE_LOGGING = True
 
 TROVE_LICENSES = {'License :: OSI Approved :: Academic Free License (AFL)': 'AFL',
                   'License :: OSI Approved :: Apache Software License': 'ASL %(TODO: version)s',

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -153,6 +153,11 @@ def get_default_save_path():
     """Return default save path for the packages"""
     macro = '%{_topdir}'
     if rpm:
-        return rpm.expandMacro(macro)
+        save_path = rpm.expandMacro(macro)
     else:
-        return rpm_eval(macro) or os.path.expanduser('~/rpmbuild')
+        save_path = rpm_eval(macro)
+        if not save_path:
+            logger.warn("rpm tools are missing, using default save path "
+                        "~/rpmbuild/.")
+            save_path = os.path.expanduser('~/rpmbuild')
+    return save_path

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -379,3 +379,15 @@ class TestWheelMetadataExtractor(object):
     def test_extract(self, i, what, expected):
         data = self.e[i].extract_data()
         assert getattr(data, what) == expected
+
+    @pytest.mark.parametrize(("input", "expected"), [
+       ([], ""),
+       (['License :: OSI Approved :: Python Software Foundation License'],
+        'Python'),
+       (['Classifier: License :: OSI Approved :: Python Software Foundation License'],
+        'Python'),
+       (['License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
+         'License :: OSI Approved :: MIT License'], 'GPLv2+ and MIT'),
+    ])
+    def test_license_from_trove(self, input, expected):
+        assert me.license_from_trove(input) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,16 +20,6 @@ class TestUtils(object):
 
         return num
 
-    @pytest.mark.parametrize(("input", "expected"), [
-        ([], ""),
-        (['License :: OSI Approved :: Python Software Foundation License'], 'Python'),
-        (['Classifier: License :: OSI Approved :: Python Software Foundation License'], 'Python'),
-        (['License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
-          'License :: OSI Approved :: MIT License'], 'GPLv2+ and MIT'),
-    ])
-    def test_license_from_trove(self, input, expected):
-        assert utils.license_from_trove(input) == expected
-
     @pytest.mark.parametrize(('input', 'expected'), [
         (['script', 'script2', 'script-0.1'], ['script', 'script2']),
         ([], []),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,12 @@
 import pytest
+import os
+from flexmock import flexmock
+try:
+    import rpm
+except ImportError:
+    rpm = None
 
 from pyp2rpm import utils
-from pyp2rpm import settings
 
 
 class TestUtils(object):
@@ -53,3 +58,27 @@ class TestUtils(object):
     ])
     def test_unique_deps(self, input, expected):
         assert utils.unique_deps(input) == expected
+
+    def test_rpm_eval(self):
+        if os.path.exists('/usr/bin/rpm'):
+            assert utils.rpm_eval('macro') == 'macro'
+        else:
+            assert utils.rpm_eval('macro') == ''
+
+    def test_get_default_save_path_eval_success(self):
+        if rpm:
+            flexmock(rpm).should_receive(
+                'expandMacro').once().and_return('foo')
+        else:
+            flexmock(utils).should_receive('rpm_eval').once().and_return('foo')
+        assert utils.get_default_save_path() == 'foo'
+
+    def test_get_default_save_path_eval_fail(self):
+        if rpm:
+            flexmock(rpm).should_receive(
+                'expandMacro').once().and_return('foo')
+        else:
+            flexmock(utils).should_receive('rpm_eval').once().and_return('')
+            flexmock(os).should_receive('path.expanduser').once(
+            ).and_return('foo')
+        assert utils.get_default_save_path() == 'foo'


### PR DESCRIPTION
Order of the methods to get DEFAULT_PKG_SAVE_PATH is following:
- rpm Python API (should work on systems where is yum/dnf installed)
- rpm --eval command
- hardcoded path ~/rpmbuild (nonrpm environments e.g. travis)

Some functions from utils had to be moved elsewhere to prevent circular dependency between utils and settings modules.