### PR TITLE
Fix error message when setup.py cannot be found

### DIFF
--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -327,7 +327,8 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
                 directory, self.archive.top_directory or self.name))[0]
         except IndexError:
             sys.stderr.write(
-                "setup.py not found, maybe local_file is not proper source archive.\n")
+                "setup.py not found, maybe {} is not "
+                "proper source archive.\n".format(self.local_file))
             raise SystemExit(3)
 
     @property


### PR DESCRIPTION
Reference `self.local_file` in an error message when setup.py can't be found. E.g change form:

```
 $ ./mybin.py jrti-game
Failed to synchronize cache for repo 'fedora-skype', disabling.
setup.py not found, maybe local_file is not proper source archive.
```
to:
```
 $ ./mybin.py jrti-game
Failed to synchronize cache for repo 'fedora-skype', disabling.
setup.py not found, maybe /home/ishcherb/rpmbuild/SOURCES/jrti_game-1.0.tar.gz is not proper source archive.
```
Also reported in #145.