### PR TITLE
Skip virtualenv tests if virtualenv-api is not installed

### DIFF
--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -198,6 +198,10 @@ class LocalMetadataExtractor(object):
         return deps_list
 
     @property
+    def venv_extraction_disabled(self):
+        return virtualenv is None or not self.venv
+
+    @property
     def versions_from_archive(self):
         """Return Python versions extracted from trove classifiers. """
         py_vers = versions_from_trove(self.classifiers)
@@ -206,7 +210,7 @@ class LocalMetadataExtractor(object):
     @property
     def has_pth(self):
         """Figure out if package has pth file """
-        if virtualenv is None:
+        if self.venv_extraction_disabled:
             return "." in self.name
         else:
             return None
@@ -250,7 +254,7 @@ class LocalMetadataExtractor(object):
         # for example nose has attribute `packages` but instead of name
         # listing the pacakges is using function to find them, that makes
         # data.packages an empty set if virtualenv is disabled
-        if virtualenv is None and getattr(data, "packages") == []:
+        if self.venv_extraction_disabled and getattr(data, "packages") == []:
             data.packages = [data.name]
 
         return data

--- a/tests/test_data/python-StructArray.spec
+++ b/tests/test_data/python-StructArray.spec
@@ -47,9 +47,9 @@ rm -rf %{pypi_name}.egg-info
 
 %files -n python2-%{pypi_name}
 %doc 
-%{python2_sitearch}/structarray.so
+%{python2_sitearch}/%{pypi_name}
 %{python2_sitearch}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
-* Wed Oct 11 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
+* Tue Nov 14 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
 - Initial package.

--- a/tests/test_data/python-StructArray_dnfnc.spec
+++ b/tests/test_data/python-StructArray_dnfnc.spec
@@ -47,9 +47,9 @@ rm -rf %{pypi_name}.egg-info
 
 %files -n python2-%{pypi_name}
 %doc 
-%{python2_sitearch}/structarray.so
+%{python2_sitearch}/%{pypi_name}
 %{python2_sitearch}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
-* Mon Oct 23 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
+* Tue Nov 14 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
 - Initial package.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,7 @@
 import pytest
 import os
+import tempfile
+import shutil
 
 from flexmock import flexmock
 from scripttest import TestFileEnvironment
@@ -20,7 +22,11 @@ class TestSpec(object):
     exe = 'python {0}mybin.py'.format(bin_dir)
 
     def setup_method(self, method):
-        self.env = TestFileEnvironment('{0}/test_output/'.format(tests_dir))
+        self.temp_dir = tempfile.mkdtemp()
+        self.env = TestFileEnvironment(self.temp_dir, start_clear=False)
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
 
     @pytest.mark.parametrize(('package', 'options', 'expected'), [
         ('Jinja2', '-v2.8', 'python-Jinja2{0}.spec'),
@@ -54,7 +60,11 @@ class TestSrpm(object):
     exe = 'python {0}mybin.py'.format(bin_dir)
 
     def setup_method(self, method):
-        self.env = TestFileEnvironment('{0}/test_output/'.format(tests_dir))
+        self.temp_dir = tempfile.mkdtemp()
+        self.env = TestFileEnvironment(self.temp_dir, start_clear=False)
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
 
     @pytest.mark.webtest
     def test_srpm(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,7 @@ class TestSpec(object):
         ('Jinja2', '-v2.8 -t epel6', 'python-Jinja2_epel6{0}.spec'),
         ('Jinja2', '-v2.8 --autonc', 'python-Jinja2_autonc.spec'),
         ('buildkit', '-v0.2.2 -b2', 'python-buildkit{0}.spec'),
-        ('StructArray', '-v0.1 -b2', 'python-StructArray{0}.spec'),
+        ('StructArray', '-v0.1 -b2 --no-venv', 'python-StructArray{0}.spec'),
         ('Sphinx', '-v1.5 -r python-sphinx', 'python-sphinx{0}.spec'),
     ])
     @pytest.mark.webtest

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -352,8 +352,7 @@ class TestWheelMetadataExtractor(object):
                 ('py2exe-0.9.2.2-py33.py34-none-any.whl',
                  'py2exe', '0.9.2.2')]:
             self.e.append(me.WheelMetadataExtractor('{0}{1}'.format(
-                self.td_dir, archive), name, self.nc, version))
-            self.e[-1].venv = None
+                self.td_dir, archive), name, self.nc, version, venv=False))
 
     @pytest.mark.parametrize(('i', 'what', 'expected'), [
         (0, 'runtime_deps', [['Requires', 'python-certifi', '==', '2015.11.20'],
@@ -364,7 +363,7 @@ class TestWheelMetadataExtractor(object):
                            ['BuildRequires', 'python-setuptools']]),
 
         (0, 'py_modules', ['_markerlib', 'pkg_resources', 'setuptools']),
-        (0, 'packages', []),
+        (0, 'packages', ['setuptools']),
         (0, 'scripts', []),
         (0, 'home_page', 'https://bitbucket.org/pypa/setuptools'),
         (0, 'summary', 'Easily download, build, install, upgrade, and uninstall Python packages'),
@@ -380,7 +379,7 @@ class TestWheelMetadataExtractor(object):
         (1, 'build_deps', [['BuildRequires', 'python2-devel'],
                            ['BuildRequires', 'python-setuptools']]),
         (1, 'py_modules', ['py2exe']),
-        (1, 'packages', []),
+        (1, 'packages', ['py2exe']),
         (1, 'scripts', ['build_exe-script.py', 'build_exe.exe']),
         (1, 'home_page', 'TODO:'),
         (1, 'summary', 'Build standalone executables for Windows (python 3 version)'),

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -2,10 +2,18 @@ import pytest
 import shutil
 import tempfile
 from flexmock import flexmock
-from pyp2rpm.virtualenv import (DirsContent, VirtualEnv, site_packages_filter,
-                                scripts_filter)
+try:
+    from pyp2rpm.virtualenv import (DirsContent,
+                                    VirtualEnv,
+                                    site_packages_filter,
+                                    scripts_filter)
+except ImportError:
+    VirtualEnv = None
 from pyp2rpm.name_convertor import NameConvertor
 from pyp2rpm.settings import DEFAULT_DISTRO, DEFAULT_PYTHON_VERSION
+
+pytestmark = pytest.mark.skipif(VirtualEnv is None,
+                                reason="virtualenv-api not installed")
 
 
 class TestUtils(object):


### PR DESCRIPTION
virtualenv-api is an optional dependency of pyp2rpm. If it is not installed related tests will be skipped. This PR also contains small change in integration tests that prevents blocking of test_output directory. Integration tests can be run in parallel inside multiple virtual environments.