### PR TITLE
BuildRequires enhancement when test suite is present

### DIFF
--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -224,6 +224,14 @@ class LocalMetadataExtractor(object):
         return self.archive.has_file_with_suffix(settings.EXTENSION_SUFFIXES)
 
     @property
+    def has_test_files(self):
+        """Check if the archive contains files, which can be collected
+        by pytest.
+        """
+        return (self.archive.get_files_re('test_.*.py') +
+                self.archive.get_files_re('.*_test.py')) != []
+
+    @property
     def srcname(self):
         """Return srcname for the macro if the pypi name should be changed.
 
@@ -460,8 +468,8 @@ class SetupPyMetadataExtractor(LocalMetadataExtractor):
         Returns:
             True if the package contains setup.py test suite, False otherwise
         """
-        return self.metadata['test_suite'] or self.metadata[
-            'tests_require'] != []
+        return (self.has_test_files or self.metadata['test_suite'] or
+                self.metadata['tests_require'] != [])
 
     @property
     def doc_files(self):
@@ -588,7 +596,8 @@ class WheelMetadataExtractor(LocalMetadataExtractor):
 
     @property
     def has_test_suite(self):
-        return self.json_metadata.get('test_requires', False) is not False
+        return self.has_test_files or self.json_metadata.get(
+            'test_requires', False) is not False
 
     @property
     def doc_files(self):

--- a/tests/test_data/python-Jinja2.spec
+++ b/tests/test_data/python-Jinja2.spec
@@ -12,9 +12,13 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildRequires:  python2-Babel >= 0.8
+BuildRequires:  python2-MarkupSafe
 BuildRequires:  python2-setuptools
  
 BuildRequires:  python3-devel
+BuildRequires:  python3-Babel >= 0.8
+BuildRequires:  python3-MarkupSafe
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-sphinx
 
@@ -78,6 +82,10 @@ rm -rf html/.{doctrees,buildinfo}
 %py2_install
 %py3_install
 
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
 %files -n python2-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
@@ -95,5 +103,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Wed Oct 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_autonc.spec
+++ b/tests/test_data/python-Jinja2_autonc.spec
@@ -12,9 +12,13 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildRequires:  python2dist(babel) >= 0.8
+BuildRequires:  python2dist(markupsafe)
 BuildRequires:  python2dist(setuptools)
  
 BuildRequires:  python3-devel
+BuildRequires:  python3dist(babel) >= 0.8
+BuildRequires:  python3dist(markupsafe)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(sphinx)
 
@@ -78,6 +82,10 @@ rm -rf html/.{doctrees,buildinfo}
 %py2_install
 %py3_install
 
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
 %files -n python2-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
@@ -95,5 +103,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Wed Oct 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_base.spec
+++ b/tests/test_data/python-Jinja2_base.spec
@@ -12,6 +12,8 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python3-devel
+BuildRequires:  python3-Babel >= 0.8
+BuildRequires:  python3-MarkupSafe
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-sphinx
 
@@ -57,6 +59,9 @@ rm -rf html/.{doctrees,buildinfo}
 %install
 %py3_install
 
+%check
+%{__python3} setup.py test
+
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
@@ -68,5 +73,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Wed Oct 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_base_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_base_dnfnc.spec
@@ -12,6 +12,8 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python3-devel
+BuildRequires:  python3-babel >= 0.8
+BuildRequires:  python3-markupsafe
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-sphinx
 
@@ -57,6 +59,9 @@ rm -rf html/.{doctrees,buildinfo}
 %install
 %py3_install
 
+%check
+%{__python3} setup.py test
+
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
@@ -68,5 +73,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon Oct 23 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_dnfnc.spec
@@ -12,9 +12,13 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildRequires:  python2-babel >= 0.8
+BuildRequires:  python2-markupsafe
 BuildRequires:  python2-setuptools
  
 BuildRequires:  python3-devel
+BuildRequires:  python3-babel >= 0.8
+BuildRequires:  python3-markupsafe
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-sphinx
 
@@ -78,6 +82,10 @@ rm -rf html/.{doctrees,buildinfo}
 %py2_install
 %py3_install
 
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
 %files -n python2-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
@@ -95,5 +103,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon Oct 23 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel6.spec
+++ b/tests/test_data/python-Jinja2_epel6.spec
@@ -1,4 +1,4 @@
-# Created by pyp2rpm-3.2.2
+# Created by pyp2rpm-3.2.3
 %global pypi_name Jinja2
 
 Name:           python-%{pypi_name}
@@ -12,6 +12,8 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildRequires:  python2-Babel >= 0.8
+BuildRequires:  python2-MarkupSafe
 BuildRequires:  python2-setuptools
 BuildRequires:  python2-sphinx
  
@@ -47,6 +49,9 @@ rm -rf html/.{doctrees,buildinfo}
 
 %install
 %{__python2} setup.py install --skip-build --root %{buildroot}
+%check
+%{__python2} setup.py test
+
 
 %files
 %doc README.rst
@@ -58,5 +63,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Tue Aug 15 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel6_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_epel6_dnfnc.spec
@@ -12,6 +12,8 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildRequires:  python2-babel >= 0.8
+BuildRequires:  python2-markupsafe
 BuildRequires:  python2-setuptools
 BuildRequires:  python2-sphinx
  
@@ -47,6 +49,9 @@ rm -rf html/.{doctrees,buildinfo}
 
 %install
 %{__python2} setup.py install --skip-build --root %{buildroot}
+%check
+%{__python2} setup.py test
+
 
 %files
 %doc README.rst
@@ -58,5 +63,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon Oct 23 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel7.spec
+++ b/tests/test_data/python-Jinja2_epel7.spec
@@ -12,10 +12,14 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildRequires:  python2-Babel >= 0.8
+BuildRequires:  python2-MarkupSafe
 BuildRequires:  python2-setuptools
 BuildRequires:  python2-sphinx
  
 BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-Babel >= 0.8
+BuildRequires:  python%{python3_pkgversion}-MarkupSafe
 BuildRequires:  python%{python3_pkgversion}-setuptools
 
 %description
@@ -76,6 +80,10 @@ rm -rf html/.{doctrees,buildinfo}
 %{__python3} setup.py install --skip-build --root %{buildroot}
 %{__python2} setup.py install --skip-build --root %{buildroot}
 
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
 %files -n python2-%{pypi_name}
 %doc README.rst
 %{python2_sitelib}/jinja2
@@ -91,5 +99,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Wed Oct 11 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-Jinja2_epel7_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_epel7_dnfnc.spec
@@ -12,10 +12,14 @@ Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildRequires:  python2-babel >= 0.8
+BuildRequires:  python2-markupsafe
 BuildRequires:  python2-setuptools
 BuildRequires:  python2-sphinx
  
 BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-babel >= 0.8
+BuildRequires:  python%{python3_pkgversion}-markupsafe
 BuildRequires:  python%{python3_pkgversion}-setuptools
 
 %description
@@ -76,6 +80,10 @@ rm -rf html/.{doctrees,buildinfo}
 %{__python3} setup.py install --skip-build --root %{buildroot}
 %{__python2} setup.py install --skip-build --root %{buildroot}
 
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
 %files -n python2-%{pypi_name}
 %doc README.rst
 %{python2_sitelib}/jinja2
@@ -91,5 +99,5 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 
 %changelog
-* Mon Oct 23 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
 - Initial package.

--- a/tests/test_data/python-StructArray.spec
+++ b/tests/test_data/python-StructArray.spec
@@ -45,11 +45,14 @@ rm -rf %{pypi_name}.egg-info
 %install
 %py2_install
 
+%check
+%{__python2} setup.py test
+
 %files -n python2-%{pypi_name}
 %doc 
 %{python2_sitearch}/%{pypi_name}
 %{python2_sitearch}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
-* Tue Nov 14 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
 - Initial package.

--- a/tests/test_data/python-StructArray_dnfnc.spec
+++ b/tests/test_data/python-StructArray_dnfnc.spec
@@ -45,11 +45,14 @@ rm -rf %{pypi_name}.egg-info
 %install
 %py2_install
 
+%check
+%{__python2} setup.py test
+
 %files -n python2-%{pypi_name}
 %doc 
 %{python2_sitearch}/%{pypi_name}
 %{python2_sitearch}/%{pypi_name}-%{version}-py?.?.egg-info
 
 %changelog
-* Tue Nov 14 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
 - Initial package.

--- a/tests/test_data/python-sphinx.spec
+++ b/tests/test_data/python-sphinx.spec
@@ -13,10 +13,46 @@ Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildConflicts: python2-babel = 2.0
+BuildRequires:  python2-Jinja2 >= 2.3
+BuildRequires:  python2-Pygments >= 2.0
+BuildRequires:  python2-alabaster < 0.8
+BuildRequires:  python2-alabaster >= 0.7
+BuildRequires:  python2-babel >= 1.3
+BuildRequires:  python2-colorama >= 0.3.5
+BuildRequires:  python2-docutils >= 0.11
+BuildRequires:  python2-html5lib
+BuildRequires:  python2-imagesize
+BuildRequires:  python2-mock
+BuildRequires:  python2-nose
+BuildRequires:  python2-requests
 BuildRequires:  python2-setuptools
+BuildRequires:  python2-simplejson
+BuildRequires:  python2-six >= 1.5
+BuildRequires:  python2-snowballstemmer >= 1.1
+BuildRequires:  python2-sqlalchemy >= 0.9
+BuildRequires:  python2-whoosh >= 2.0
  
 BuildRequires:  python3-devel
+BuildConflicts: python3-babel = 2.0
+BuildRequires:  python3-Jinja2 >= 2.3
+BuildRequires:  python3-Pygments >= 2.0
+BuildRequires:  python3-alabaster < 0.8
+BuildRequires:  python3-alabaster >= 0.7
+BuildRequires:  python3-babel >= 1.3
+BuildRequires:  python3-colorama >= 0.3.5
+BuildRequires:  python3-docutils >= 0.11
+BuildRequires:  python3-html5lib
+BuildRequires:  python3-imagesize
+BuildRequires:  python3-mock
+BuildRequires:  python3-nose
+BuildRequires:  python3-requests
 BuildRequires:  python3-setuptools
+BuildRequires:  python3-simplejson
+BuildRequires:  python3-six >= 1.5
+BuildRequires:  python3-snowballstemmer >= 1.1
+BuildRequires:  python3-sqlalchemy >= 0.9
+BuildRequires:  python3-whoosh >= 2.0
 BuildRequires:  python3-sphinx
 
 %description
@@ -114,6 +150,10 @@ rm -rf html/.{doctrees,buildinfo}
 rm -rf %{buildroot}%{_bindir}/*
 %py3_install
 
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
 %files -n python2-%{srcname}
 %license LICENSE
 %doc README.rst
@@ -135,5 +175,5 @@ rm -rf %{buildroot}%{_bindir}/*
 %license LICENSE
 
 %changelog
-* Tue Oct 24 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
 - Initial package.

--- a/tests/test_data/python-sphinx_dnfnc.spec
+++ b/tests/test_data/python-sphinx_dnfnc.spec
@@ -13,10 +13,46 @@ Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{
 BuildArch:      noarch
  
 BuildRequires:  python2-devel
+BuildConflicts: python2-babel = 2.0
+BuildRequires:  python2-alabaster < 0.8
+BuildRequires:  python2-alabaster >= 0.7
+BuildRequires:  python2-babel >= 1.3
+BuildRequires:  python2-colorama >= 0.3.5
+BuildRequires:  python2-docutils >= 0.11
+BuildRequires:  python2-html5lib
+BuildRequires:  python2-imagesize
+BuildRequires:  python2-jinja2 >= 2.3
+BuildRequires:  python2-mock
+BuildRequires:  python2-nose
+BuildRequires:  python2-pygments >= 2.0
+BuildRequires:  python2-requests
 BuildRequires:  python2-setuptools
+BuildRequires:  python2-simplejson
+BuildRequires:  python2-six >= 1.5
+BuildRequires:  python2-snowballstemmer >= 1.1
+BuildRequires:  python2-sqlalchemy >= 0.9
+BuildRequires:  python2-whoosh >= 2.0
  
 BuildRequires:  python3-devel
+BuildConflicts: python3-babel = 2.0
+BuildRequires:  python3-alabaster < 0.8
+BuildRequires:  python3-alabaster >= 0.7
+BuildRequires:  python3-babel >= 1.3
+BuildRequires:  python3-colorama >= 0.3.5
+BuildRequires:  python3-docutils >= 0.11
+BuildRequires:  python3-html5lib
+BuildRequires:  python3-imagesize
+BuildRequires:  python3-jinja2 >= 2.3
+BuildRequires:  python3-mock
+BuildRequires:  python3-nose
+BuildRequires:  python3-pygments >= 2.0
+BuildRequires:  python3-requests
 BuildRequires:  python3-setuptools
+BuildRequires:  python3-simplejson
+BuildRequires:  python3-six >= 1.5
+BuildRequires:  python3-snowballstemmer >= 1.1
+BuildRequires:  python3-sqlalchemy >= 0.9
+BuildRequires:  python3-whoosh >= 2.0
 BuildRequires:  python3-sphinx
 
 %description
@@ -114,6 +150,10 @@ rm -rf html/.{doctrees,buildinfo}
 rm -rf %{buildroot}%{_bindir}/*
 %py3_install
 
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
 %files -n python2-%{srcname}
 %license LICENSE
 %doc README.rst
@@ -135,5 +175,5 @@ rm -rf %{buildroot}%{_bindir}/*
 %license LICENSE
 
 %changelog
-* Tue Oct 24 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
+* Tue Dec 05 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
 - Initial package.

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -307,6 +307,7 @@ class TestSetupPyMetadataExtractor(object):
         (1, 'runtime_deps', [['Requires', 'python-py', '>=', '1.4.7.dev2'],
                              ['Requires', 'python-setuptools']]),
         (1, 'build_deps', [['BuildRequires', 'python2-devel'],
+                           ['BuildRequires', 'python-py', '>=', '1.4.7.dev2'],
                            ['BuildRequires', 'python-setuptools'],
                            ['BuildRequires', 'python-sphinx']]),
         (1, 'py_modules', ['pytest']),
@@ -371,6 +372,8 @@ class TestWheelMetadataExtractor(object):
         (0, 'build_deps', [['BuildRequires', 'python2-devel'],
                            ['BuildRequires', 'python-pytest', '>=', '2.8'],
                            ['BuildRequires', 'python-setuptools[ssl]'],
+                           ['BuildRequires', 'python-certifi', '==',
+                            '2015.11.20'],
                            ['BuildRequires', 'python-setuptools']]),
 
         (0, 'py_modules', ['_markerlib', 'pkg_resources', 'setuptools']),

--- a/tests/test_metadata_extractors.py
+++ b/tests/test_metadata_extractors.py
@@ -217,6 +217,17 @@ stripped.  for example:  ::      [nosetests]     warningfilters=default
     def test_cut_to_length(self, text, length, delim, expected):
         assert me.cut_to_length(text, length, delim) == expected
 
+    @pytest.mark.parametrize(('i', 'expected'), [
+        (0, False),
+        (1, True),
+        (2, True),
+        (3, False),
+        (4, False),
+    ])
+    def test_has_test_files(self, i, expected):
+        with self.e[i].archive:
+            assert self.e[i].has_test_files == expected
+
 
 class TestPyPIMetadataExtension(object):
     td_dir = '{0}/test_data/'.format(tests_dir)
@@ -305,7 +316,7 @@ class TestSetupPyMetadataExtractor(object):
         (1, 'license', 'MIT license'),
         (1, 'has_pth', False),
         (1, 'has_extension', False),
-        (1, 'has_test_suite', False),
+        (1, 'has_test_suite', True),
         (1, 'has_packages', True),
         (1, 'has_bundled_egg_info', True),
         (1, 'doc_files', ['README.txt']),


### PR DESCRIPTION
Detection of test suite based on data from setup.py is not reliable. Check if the archive contains tests/ directory was added. In case the test suite is detected, all the install requires are added to BuildRequires as well to make sure all the dependencies to run integration tests will be available in the Buildroot.