### PR TITLE
Fix pulling the lowest release version of the package from PyPI

### DIFF
--- a/pyp2rpm/package_getters.py
+++ b/pyp2rpm/package_getters.py
@@ -140,7 +140,7 @@ class PypiDownloader(PackageGetter):
             raise exceptions.NoSuchPackageException(
                 'Package "{0}" could not be found on PyPI.'.format(name))
 
-        self.version = version or self.versions[0]
+        self.version = version or self.versions[-1]
 
         # if version is specified, will check if such version exists
         if version and self.client.release_urls(name, version) == []:

--- a/tests/test_package_getters.py
+++ b/tests/test_package_getters.py
@@ -58,7 +58,7 @@ class TestPackageGetters(object):
 
 class TestPypiFileGetter(object):
     client = flexmock(
-        package_releases=lambda n: n == 'spam' and ['2', '1'] or [],
+        package_releases=lambda n: n == 'spam' and ['1', '2'] or [],
         release_urls=lambda n, v: n == 'spam' and v in [
             '2', '1'] and [{'url': 'spam'}] or []
     )


### PR DESCRIPTION
After we switched to https://pypi.org/pypi, the order in which `package_releases` are returned has changed, and we now get releases starting from oldest to the most recent. As we depend on that ordering, pyp2rpm was creating a spec file for the lowest version of the package.

The integration tests did not catch that, because we specify version with `-v` option to avoid broken tests every time the package gets updated on PyPI.