### PR TITLE
Fix traceback when extracting metadata from .whl is not possible due to missing files

### DIFF
--- a/tests/test_name_convertor.py
+++ b/tests/test_name_convertor.py
@@ -70,7 +70,7 @@ class TestDandifiedNameConvertor(object):
         ('Cython', '3', 'python3-Cython'),
         ('pytest', '2', 'python2-pytest'),
         ('pytest', '3', 'python3-pytest'),
-        ('vertica', '2', 'vertica-python'),
+        ('vertica', '2', 'python2-vertica'),
         ('oslosphinx', '2', 'python2-oslo-sphinx'),
         ('oslosphinx', '3', 'python3-oslo-sphinx'),
         ('mock', '2', 'python2-mock'),


### PR DESCRIPTION
Fixes #159 

Output in the case reported in the issue:
```
$ ./mybin.py sphinxcontrib_github_alt -s
INFO  Pyp2rpm initialized.
INFO  Using /home/ishcherb/rpmbuild/SOURCES as directory to save source.
INFO  Downloaded package from PyPI: /tmp/tmppy5hne3m/sphinxcontrib_github_alt-1.0-py2.py3-none-any.whl.
INFO  Getting metadata from wheel using WheelMetadataExtractor.
WARNING  Could not extract metadata from metadata.json. Error: the JSON object must be str, bytes or bytearray, not 'NoneType'
WARNING  Could not extract metadata from pydist.json. Error: the JSON object must be str, bytes or bytearray, not 'NoneType'
Unable to extract package metadata from .whl archive. Make sure that the .dist-info directory contains either metadata.json or pydist.json file of valid JSON format
```

This PR also contains a fix for tests, introduced by renaming `vertica-python` to `python2-vertica` in Fedora Rawhide (as we use Fedora Rawhide docker image to run tests on Travis CI).