### PR TITLE
Rebase Mageia template based on latest Python Packaging Policy

### DIFF
--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -214,7 +214,8 @@ class Convertor(object):
             name_convertor.NameConvertor.template = os.path.splitext(
                 self.template)[0]
             if self.autonc or (self.autonc is None and
-                self.template == 'fedora.spec'):
+                (self.template == 'fedora.spec' or
+                 self.template == 'mageia.spec')):
                 logger.debug("Using AutoProvidesNameConvertor to convert "
                              "names of the packages.")
                 self._name_convertor = name_convertor.AutoProvidesNameConvertor(

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -5,7 +5,7 @@ DEFAULT_PYTHON_VERSIONS = {
     'fedora': ['3', '2'],
     'epel7': ['2', '3'],
     'epel6': ['2'],
-    'mageia': ['2', '3'],
+    'mageia': ['3', '2'],
     'pld': ['2', '3']
 }
 DEFAULT_PYTHON_VERSION = DEFAULT_PYTHON_VERSIONS[DEFAULT_TEMPLATE][0]


### PR DESCRIPTION
Mageia's packaging, as of Mageia 7, is similar to how Fedora packages Python modules.

With Mageia 7, we are also using the new dependency generator by default and Python 3 is now the default.