### PR TITLE
Use a glob that allows arbitrary python version numbers.

### DIFF
--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -131,9 +131,9 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -141,9 +141,9 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- endif %}
 {% endcall %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -131,9 +131,9 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -141,9 +141,9 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- endif %}
 {% endcall %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/epel6.spec
+++ b/pyp2rpm/templates/epel6.spec
@@ -131,9 +131,9 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -141,9 +141,9 @@ popd
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- endif %}
 {% endcall %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -99,9 +99,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -109,9 +109,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -99,9 +99,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -109,9 +109,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/epel7.spec
+++ b/pyp2rpm/templates/epel7.spec
@@ -99,9 +99,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -109,9 +109,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -102,9 +102,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -112,9 +112,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -102,9 +102,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -112,9 +112,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -102,9 +102,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -112,9 +112,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/mageia.spec
+++ b/pyp2rpm/templates/mageia.spec
@@ -102,9 +102,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -112,9 +112,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py?.?.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/mageia.spec
+++ b/pyp2rpm/templates/mageia.spec
@@ -102,9 +102,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -112,9 +112,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py*.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/mageia.spec
+++ b/pyp2rpm/templates/mageia.spec
@@ -102,9 +102,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitearch}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 {%- for package in data.packages %}
@@ -112,9 +112,9 @@ rm -rf %{buildroot}%{_bindir}/*
 {%- endfor %}
 {%- endif %}
 {%- if data.has_pth %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}-*.pth
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python3_version}.egg-info
+%{python{{ pv }}_sitelib}/{{ underscored_or_pypi(data.name, data.underscored_name) }}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- endif %}
 {% endfor %}
 {%- if data.sphinx_dir %}

--- a/pyp2rpm/templates/pld.spec
+++ b/pyp2rpm/templates/pld.spec
@@ -149,18 +149,18 @@ rm -rf $RPM_BUILD_ROOT
 {%- if data.has_extension %}
 %{py{{ v }}_sitedir/%{module}
 {%- if data.has_pth %}
-%{py{{ v }}_sitedir/%{egg_name}-%{version}-py*-*.pth
+%{py{{ v }}_sitedir/%{egg_name}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{py{{ v }}_sitedir/%{egg_name}-%{version}-py*.egg-info
+%{py{{ v }}_sitedir/%{egg_name}-%{version}-py%{python3_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 %{py{{ v }}_sitescriptdir}/%{module}
 {%- endif %}
 
 {%- if data.has_pth %}
-%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py*-*.pth
+%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py%{python3_version}-*.pth
 {%- endif %}
-%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py*.egg-info
+%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py%{python3_version}.egg-info
 {%- endif %}
 
 {%- endcall %}

--- a/pyp2rpm/templates/pld.spec
+++ b/pyp2rpm/templates/pld.spec
@@ -149,18 +149,18 @@ rm -rf $RPM_BUILD_ROOT
 {%- if data.has_extension %}
 %{py{{ v }}_sitedir/%{module}
 {%- if data.has_pth %}
-%{py{{ v }}_sitedir/%{egg_name}-%{version}-py%{python3_version}-*.pth
+%{py{{ v }}_sitedir/%{egg_name}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{py{{ v }}_sitedir/%{egg_name}-%{version}-py%{python3_version}.egg-info
+%{py{{ v }}_sitedir/%{egg_name}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- else %}
 {%- if data.has_packages %}
 %{py{{ v }}_sitescriptdir}/%{module}
 {%- endif %}
 
 {%- if data.has_pth %}
-%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py%{python3_version}-*.pth
+%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py%{python{{ pv }}_version}-*.pth
 {%- endif %}
-%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py%{python3_version}.egg-info
+%{py{{ v }}_sitescriptdir}/%{egg_name}-%{version}-py%{python{{ pv }}_version}.egg-info
 {%- endif %}
 
 {%- endcall %}

--- a/tests/test_data/python-Jinja2_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_dnfnc.spec
@@ -90,13 +90,13 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python3_sitelib}/jinja2
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_dnfnc.spec
@@ -90,7 +90,7 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE

--- a/tests/test_data/python-Jinja2_epel6_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_epel6_dnfnc.spec
@@ -56,7 +56,7 @@ rm -rf html/.{doctrees,buildinfo}
 %files
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_epel6_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_epel6_dnfnc.spec
@@ -56,7 +56,7 @@ rm -rf html/.{doctrees,buildinfo}
 %files
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_epel6_nc.spec
+++ b/tests/test_data/python-Jinja2_epel6_nc.spec
@@ -56,7 +56,7 @@ rm -rf html/.{doctrees,buildinfo}
 %files
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_epel6_nc.spec
+++ b/tests/test_data/python-Jinja2_epel6_nc.spec
@@ -56,7 +56,7 @@ rm -rf html/.{doctrees,buildinfo}
 %files
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_epel7_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_epel7_dnfnc.spec
@@ -87,12 +87,12 @@ rm -rf html/.{doctrees,buildinfo}
 %files -n python2-%{pypi_name}
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python%{python3_pkgversion}-%{pypi_name}
 %doc README.rst
 %{python3_sitelib}/jinja2
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_epel7_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_epel7_dnfnc.spec
@@ -87,7 +87,7 @@ rm -rf html/.{doctrees,buildinfo}
 %files -n python2-%{pypi_name}
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python%{python3_pkgversion}-%{pypi_name}
 %doc README.rst

--- a/tests/test_data/python-Jinja2_epel7_nc.spec
+++ b/tests/test_data/python-Jinja2_epel7_nc.spec
@@ -87,12 +87,12 @@ rm -rf html/.{doctrees,buildinfo}
 %files -n python2-%{pypi_name}
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python%{python3_pkgversion}-%{pypi_name}
 %doc README.rst
 %{python3_sitelib}/jinja2
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_epel7_nc.spec
+++ b/tests/test_data/python-Jinja2_epel7_nc.spec
@@ -87,7 +87,7 @@ rm -rf html/.{doctrees,buildinfo}
 %files -n python2-%{pypi_name}
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python%{python3_pkgversion}-%{pypi_name}
 %doc README.rst

--- a/tests/test_data/python-Jinja2_mageia_py23.spec
+++ b/tests/test_data/python-Jinja2_mageia_py23.spec
@@ -90,13 +90,13 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python3_sitelib}/jinja2
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_mageia_py23.spec
+++ b/tests/test_data/python-Jinja2_mageia_py23.spec
@@ -90,7 +90,7 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE

--- a/tests/test_data/python-Jinja2_nc.spec
+++ b/tests/test_data/python-Jinja2_nc.spec
@@ -90,13 +90,13 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python3_sitelib}/jinja2
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_nc.spec
+++ b/tests/test_data/python-Jinja2_nc.spec
@@ -90,7 +90,7 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE

--- a/tests/test_data/python-Jinja2_py23_autonc.spec
+++ b/tests/test_data/python-Jinja2_py23_autonc.spec
@@ -90,13 +90,13 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python3_sitelib}/jinja2
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_py23_autonc.spec
+++ b/tests/test_data/python-Jinja2_py23_autonc.spec
@@ -90,7 +90,7 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python3-%{pypi_name}
 %license docs/_themes/LICENSE LICENSE

--- a/tests/test_data/python-Jinja2_py2_autonc.spec
+++ b/tests/test_data/python-Jinja2_py2_autonc.spec
@@ -66,7 +66,7 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_py2_autonc.spec
+++ b/tests/test_data/python-Jinja2_py2_autonc.spec
@@ -66,7 +66,7 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python2_sitelib}/jinja2
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-Jinja2_py3_autonc.spec
+++ b/tests/test_data/python-Jinja2_py3_autonc.spec
@@ -66,7 +66,7 @@ rm -rf html/.{doctrees,buildinfo}
 %license docs/_themes/LICENSE LICENSE
 %doc README.rst
 %{python3_sitelib}/jinja2
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{pypi_name}-doc
 %doc html

--- a/tests/test_data/python-StructArray_autonc.spec
+++ b/tests/test_data/python-StructArray_autonc.spec
@@ -50,7 +50,7 @@ rm -rf %{pypi_name}.egg-info
 
 %files -n python2-%{pypi_name}
 %{python2_sitearch}/%{pypi_name}
-%{python2_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitearch}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %changelog
 * Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1

--- a/tests/test_data/python-StructArray_autonc.spec
+++ b/tests/test_data/python-StructArray_autonc.spec
@@ -50,7 +50,7 @@ rm -rf %{pypi_name}.egg-info
 
 %files -n python2-%{pypi_name}
 %{python2_sitearch}/%{pypi_name}
-%{python2_sitearch}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
 * Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1

--- a/tests/test_data/python-buildkit_autonc.spec
+++ b/tests/test_data/python-buildkit_autonc.spec
@@ -51,7 +51,7 @@ rm -rf %{pypi_name}.egg-info
 %license LICENSE.txt
 %doc example/README.txt README.txt
 %{python2_sitelib}/%{pypi_name}
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %changelog
 * Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 0.2.2-1

--- a/tests/test_data/python-buildkit_autonc.spec
+++ b/tests/test_data/python-buildkit_autonc.spec
@@ -51,7 +51,7 @@ rm -rf %{pypi_name}.egg-info
 %license LICENSE.txt
 %doc example/README.txt README.txt
 %{python2_sitelib}/%{pypi_name}
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
 * Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 0.2.2-1

--- a/tests/test_data/python-paperwork-backend.spec
+++ b/tests/test_data/python-paperwork-backend.spec
@@ -55,7 +55,7 @@ rm -rf %{pypi_name}.egg-info
 %doc README.markdown
 %{_bindir}/paperwork-shell
 %{python3_sitelib}/paperwork_backend
-%{python3_sitelib}/paperwork_backend-%{version}-py?.?.egg-info
+%{python3_sitelib}/paperwork_backend-%{version}-py%{python3_version}.egg-info
 
 %changelog
 * Thu Mar 21 2019 Miro Hrončok <mhroncok@redhat.com> - 1.2.4-1

--- a/tests/test_data/python-sphinx_autonc.spec
+++ b/tests/test_data/python-sphinx_autonc.spec
@@ -158,7 +158,7 @@ rm -rf %{buildroot}%{_bindir}/*
 %license LICENSE
 %doc README.rst
 %{python2_sitelib}/sphinx
-%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python3-%{srcname}
 %license LICENSE
@@ -168,7 +168,7 @@ rm -rf %{buildroot}%{_bindir}/*
 %{_bindir}/sphinx-build
 %{_bindir}/sphinx-quickstart
 %{python3_sitelib}/sphinx
-%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %files -n python-%{srcname}-doc
 %doc html

--- a/tests/test_data/python-sphinx_autonc.spec
+++ b/tests/test_data/python-sphinx_autonc.spec
@@ -158,7 +158,7 @@ rm -rf %{buildroot}%{_bindir}/*
 %license LICENSE
 %doc README.rst
 %{python2_sitelib}/sphinx
-%{python2_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
 
 %files -n python3-%{srcname}
 %license LICENSE


### PR DESCRIPTION
If python 3.10 comes after 3.9, the globs used in the templates may break.