### PR TITLE
en_US locale does not exist in rawhide containers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM fedora:rawhide
 
 ENV PIP_NO_CACHE_DIR=off \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
 
 LABEL summary="Image for running automatic tests of pyp2rpm in Travis CI" \
       name="pyp2rpm-tests" \


### PR DESCRIPTION
The en_US locale is not installed in rawhide containers.  glibc will indicate that the locale is unsupported when setlocale() is called, which causes various errors in Python.  Setting LANG and LC_ALL to C.UTF-8 will set a UTF-8 encoding by default, but use the built-in locale.  This resolves some of the errors currently occurring in the test suite.