### PR TITLE
Use logging.warning instead of the obsolete logging.warn.

### DIFF
--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -158,9 +158,9 @@ class Convertor(object):
                 os.path.abspath(self.template))
         except jinja2.exceptions.TemplateNotFound:
             # absolute path not found => search in default template dir
-            logger.warn('Template: {0} was not found in {1} using default '
-                        'template dir.'.format(
-                            self.template, os.path.abspath(self.template)))
+            logger.warning('Template: {0} was not found in {1} using default '
+                           'template dir.'.format(
+                               self.template, os.path.abspath(self.template)))
 
             jinja_template = jinja_env.get_template(self.template)
             logger.info('Using default template: {0}.'.format(self.template))
@@ -227,9 +227,9 @@ class Convertor(object):
                 self._name_convertor = name_convertor.AutoProvidesNameConvertor(
                     self.distro)
             elif dnf is None:
-                logger.warn("Dnf module not found, please dnf install "
-                            "python{0}-dnf to improve accuracy of name "
-                            "conversion.".format(sys.version[0]))
+                logger.warning("Dnf module not found, please dnf install "
+                               "python{0}-dnf to improve accuracy of name "
+                               "conversion.".format(sys.version[0]))
                 logger.debug(
                     "Using NameConvertor to convert names of the packages.")
                 self._name_convertor = name_convertor.NameConvertor(

--- a/pyp2rpm/package_getters.py
+++ b/pyp2rpm/package_getters.py
@@ -113,11 +113,11 @@ class PackageGetter(object):
                 except OSError:
                     self.save_dir = '/tmp'
                     # pyp2rpm can work without rpmdevtools
-                    logger.warn("Package rpmdevtools is missing , using "
-                                "default folder: {0} to store {1}.".format(
-                                    self.save_dir, self.name))
-                    logger.warn("Specify folder to store a file (SAVE_DIR) "
-                                "or install rpmdevtools.")
+                    logger.warning("Package rpmdevtools is missing , using "
+                                   "default folder: {0} to store {1}.".format(
+                                       self.save_dir, self.name))
+                    logger.warning("Specify folder to store a file (SAVE_DIR) "
+                                   "or install rpmdevtools.")
         logger.info("Using {0} as directory to save source.".format(
             self.save_dir))
 

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -163,7 +163,7 @@ def get_default_save_path():
     else:
         save_path = rpm_eval(macro)
         if not save_path:
-            logger.warn("rpm tools are missing, using default save path "
-                        "~/rpmbuild/.")
+            logger.warning("rpm tools are missing, using default save path "
+                           "~/rpmbuild/.")
             save_path = os.path.expanduser('~/rpmbuild')
     return save_path


### PR DESCRIPTION
"logging.warn" is deprecated and generates hundreds of warnings during testing.  warning is present in 2.7 and all of the supported 3 releases:

https://docs.python.org/2.7/library/logging.html#logging.warning