### PR TITLE
Leave locale set to 'C' if restoring the previous one fails.

### DIFF
--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -139,7 +139,14 @@ def c_time_locale():
     old_time_locale = locale.getlocale(locale.LC_TIME)
     locale.setlocale(locale.LC_TIME, 'C')
     yield
-    locale.setlocale(locale.LC_TIME, old_time_locale)
+    try:
+        locale.setlocale(locale.LC_TIME, old_time_locale)
+    except locale.Error:
+        # https://bugs.python.org/issue30755
+        # Python may alias the configured locale to another name, and
+        # that locale may not be installed.  In this case, the locale
+        # should simply be left in the 'C' locale.
+        pass
 
 
 def rpm_eval(macro):


### PR DESCRIPTION
There is already a bug filed for this issue:
https://bugs.python.org/issue30755

One perfectly reasonable response to this condition is simply to leave the locale set to 'C'.  The other would be to modify Dockerfile to install en_US support, so that we don't have to work around bugs in Python.  If you'd prefer that option, I can send a different PR.