### PR TITLE
Fix py 30755 opt2

### DIFF
--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -139,7 +139,14 @@ def c_time_locale():
     old_time_locale = locale.getlocale(locale.LC_TIME)
     locale.setlocale(locale.LC_TIME, 'C')
     yield
-    locale.setlocale(locale.LC_TIME, old_time_locale)
+    try:
+        locale.setlocale(locale.LC_TIME, old_time_locale)
+    except locale.Error:
+        # https://bugs.python.org/issue30755
+        # Python may alias the configured locale to another name, and
+        # that locale may not be installed.  In this case, the locale
+        # should simply be left in the 'C' locale.
+        pass
 
 
 def rpm_eval(macro):

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -144,9 +144,13 @@ def c_time_locale():
     except locale.Error:
         # https://bugs.python.org/issue30755
         # Python may alias the configured locale to another name, and
-        # that locale may not be installed.  In this case, the locale
-        # should simply be left in the 'C' locale.
-        pass
+        # that locale may not be installed.  Attempt to use the built-in
+        # locale with UTF-8 support, and if that fails then use
+        # the built-in locale without UTF-8.
+        try:
+            locale.setlocale(locale.LC_TIME, 'C.UTF-8')
+        except locale.Error:
+            locale.setlocale(locale.LC_TIME, 'C')
 
 
 def rpm_eval(macro):


### PR DESCRIPTION
Another option for locale handling:

This branch mostly adopts dnf's behavior, with the caveat that on an affected python3 platform, the "c.utf-8" locale will not be used, because Python will translate that to "en_US.UTF-8" which may not be installed.