### PR TITLE
Fix py 30755 opt3

### DIFF
--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -139,7 +139,14 @@ def c_time_locale():
     old_time_locale = locale.getlocale(locale.LC_TIME)
     locale.setlocale(locale.LC_TIME, 'C')
     yield
-    locale.setlocale(locale.LC_TIME, old_time_locale)
+    try:
+        locale.setlocale(locale.LC_TIME, old_time_locale)
+    except locale.Error:
+        # https://bugs.python.org/issue30755
+        # Python may alias the configured locale to another name, and
+        # that locale may not be installed.  In this case, the locale
+        # should simply be left in the 'C' locale.
+        pass
 
 
 def rpm_eval(macro):

--- a/pyp2rpm/utils.py
+++ b/pyp2rpm/utils.py
@@ -144,9 +144,13 @@ def c_time_locale():
     except locale.Error:
         # https://bugs.python.org/issue30755
         # Python may alias the configured locale to another name, and
-        # that locale may not be installed.  In this case, the locale
-        # should simply be left in the 'C' locale.
-        pass
+        # that locale may not be installed.  Attempt to use the built-in
+        # locale with UTF-8 support, and if that fails then use
+        # the built-in locale without UTF-8.
+        try:
+            locale.setlocale(locale.LC_TIME, 'C.UTF-8')
+        except locale.Error:
+            locale.setlocale(locale.LC_TIME, 'C')
 
 
 def rpm_eval(macro):


### PR DESCRIPTION
Another option for locale handling:

If we are running in an environment that doesn't have en_US.UTF-8, and is configured for C.UTF-8, we need to delete the "c.utf8" alias from the locale module before we check our locale with getlocale().  Otherwise, Python will report the wrong locale, as demonstrated below:

```
[root@53bd20de2fd8 /]# python3
Python 3.7.4rc1 (default, Jun 26 2019, 10:45:53) 
[GCC 9.1.1 20190605 (Red Hat 9.1.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import locale
>>> import dnf
Failed to set locale, defaulting to C.UTF-8
>>> locale.getlocale(locale.LC_TIME)
('en_US', 'UTF-8')
>>> del(locale.locale_alias['c.utf8'])
>>> locale.getlocale(locale.LC_TIME)
('C', 'UTF-8')
```