### PR TITLE
Fix repeated calls to rpm_versioned_name.

### DIFF
--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -4,7 +4,7 @@ from pyp2rpm import name_convertor
 
 def name_for_python_version(name, version, default_number=False):
     return name_convertor.NameConvertor.rpm_versioned_name(
-        name, version, default_number)
+        name, version, default_number, True)
 
 
 def script_name_for_python_version(name, version, minor=False,

--- a/pyp2rpm/name_convertor.py
+++ b/pyp2rpm/name_convertor.py
@@ -33,7 +33,8 @@ class NameConvertor(object):
                 settings.DEFAULT_TEMPLATE][0]
 
     @classmethod
-    def rpm_versioned_name(cls, name, version, default_number=False):
+    def rpm_versioned_name(cls, name, version, default_number=False,
+                           use_macros=False):
         """Properly versions the name.
         For example:
         rpm_versioned_name('python-foo', '26') will return python26-foo
@@ -74,10 +75,10 @@ class NameConvertor(object):
 
             else:
                 versioned_name = 'python{0}-{1}'.format(version, name)
-            if ('epel' in cls.distro and version !=
+            if (use_macros and 'epel' in cls.distro and version !=
                     cls.get_default_py_version()):
-                versioned_name = versioned_name.replace('{0}'.format(
-                    version), '%{{python{0}_pkgversion}}'.format(version))
+                versioned_name = versioned_name.replace('python{0}-'.format(
+                    version), 'python%{{python{0}_pkgversion}}-'.format(version))
         return versioned_name
 
     def rpm_name(self, name, python_version=None, pkg_name=False):


### PR DESCRIPTION
rpm_versioned_name is called on package names multiple times in different contexts.  In the corner case of building a spec for EPEL where the base version is python3, this will lead to bad expansions:

```
Requires:       python%{python3_pkgversion}-python%{python%{python3_pkgversion}_pkgversion}-pulpcore-plugin >= 0.1rc2
Conflicts:      python%{python3_pkgversion}-python%{python%{python3_pkgversion}_pkgversion}-pulpcore-plugin >= 0.2

```