### PR TITLE
Use pypi_source macro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL summary="Image for running automatic tests of pyp2rpm in Travis CI" \
       maintainer="Michal Cyprian <mcyprian@redhat.com>"
 
 RUN INSTALL_PKGS="gcc tox python27 python34 python35 python36 python37\
-                  python2-setuptools python3-setuptools" && \
+                  python2-setuptools python3-setuptools python-srpm-macros" && \
     dnf -y install --setopt=install_weak_deps=false --setopt=tsflags=nodocs \
                    --setopt=deltarpm=false $INSTALL_PKGS && \
     dnf clean all

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -20,10 +20,13 @@ try:
     import dnf
 except ImportError:
     dnf = None
+try:
+    import rpm
+except ImportError:
+    rpm = None
 
 import jinja2
 import pprint
-import rpm
 
 from pyp2rpm import exceptions
 from pyp2rpm import filters
@@ -149,8 +152,9 @@ class Convertor(object):
 
         # Set the name and version macros so that rpmlib can expand
         # pypi_source
-        rpm.addMacro('name', self.package)
-        rpm.addMacro('version', self.version)
+        if rpm:
+            rpm.addMacro('name', self.package)
+            rpm.addMacro('version', self.version)
 
         jinja_env = jinja2.Environment(loader=jinja2.ChoiceLoader([
             jinja2.FileSystemLoader(['/']),

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -23,6 +23,7 @@ except ImportError:
 
 import jinja2
 import pprint
+import rpm
 
 from pyp2rpm import exceptions
 from pyp2rpm import filters
@@ -145,6 +146,11 @@ class Convertor(object):
         logger.debug("Extracted metadata:")
         logger.debug(pprint.pformat(data.data))
         self.merge_versions(data)
+
+        # Set the name and version macros so that rpmlib can expand
+        # pypi_source
+        rpm.addMacro('name', self.package)
+        rpm.addMacro('version', self.version)
 
         jinja_env = jinja2.Environment(loader=jinja2.ChoiceLoader([
             jinja2.FileSystemLoader(['/']),

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -1,3 +1,4 @@
+from rpm import expandMacro
 from pyp2rpm import settings
 from pyp2rpm import name_convertor
 
@@ -61,6 +62,13 @@ def package_to_path(package, module):
     else:
         return package
 
+def macroed_url(url):
+    val = expandMacro('%{pypi_source}')
+    if val == url:
+        return "%{pypi_source}"
+    else:
+        return url
+
 
 __all__ = [name_for_python_version,
            script_name_for_python_version,
@@ -68,4 +76,5 @@ __all__ = [name_for_python_version,
            python_bin_for_python_version,
            macroed_pkg_name,
            module_to_path,
-           package_to_path]
+           package_to_path,
+           macroed_url]

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -1,4 +1,7 @@
-from rpm import expandMacro
+try:
+    import rpm
+except:
+    rpm = None
 from pyp2rpm import settings
 from pyp2rpm import name_convertor
 
@@ -63,6 +66,8 @@ def package_to_path(package, module):
         return package
 
 def macroed_url(url):
+    if not rpm:
+        return url
     val = expandMacro('%{pypi_source}')
     if val == url:
         return "%{pypi_source}"

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -68,7 +68,7 @@ def package_to_path(package, module):
 def macroed_url(url):
     if not rpm:
         return url
-    val = expandMacro('%{pypi_source}')
+    val = rpm.expandMacro('%{pypi_source}')
     if val == url:
         return "%{pypi_source}"
     else:

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -1,5 +1,5 @@
 {{ data.credit_line }}
-{% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
+{% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi, macroed_url -%}
 %global pypi_name {{ data.name }}
 {%- if data.srcname %}
 %global srcname {{ data.srcname }}
@@ -12,7 +12,7 @@ Summary:        {{ data.summary }}
 
 License:        {{ data.license }}
 URL:            {{ data.home_page }}
-Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:        {{ data.source0|macroed_url|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
 
 {%- if not data.has_extension %}
 BuildArch:      noarch
@@ -50,7 +50,7 @@ rm -rf %{pypi_name}.egg-info
 %py{{ pv }}_build
 {%- endfor %}
 {%- if data.sphinx_dir %}
-# generate html docs 
+# generate html docs
 PYTHONPATH=${PWD} {{ "sphinx-build"|script_name_for_python_version(data.base_python_version, False, True) }} {{ data.sphinx_dir }} html
 # remove the sphinx-build leftovers
 rm -rf html/.{doctrees,buildinfo}

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -50,7 +50,7 @@ rm -rf %{pypi_name}.egg-info
 %py{{ pv }}_build
 {%- endfor %}
 {%- if data.sphinx_dir %}
-# generate html docs
+# generate html docs 
 PYTHONPATH=${PWD} {{ "sphinx-build"|script_name_for_python_version(data.base_python_version, False, True) }} {{ data.sphinx_dir }} html
 # remove the sphinx-build leftovers
 rm -rf html/.{doctrees,buildinfo}

--- a/tests/test_data/pypi_source/python-Jinja2_dnfnc.spec
+++ b/tests/test_data/pypi_source/python-Jinja2_dnfnc.spec
@@ -1,0 +1,107 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python2-devel
+BuildRequires:  python2-babel >= 0.8
+BuildRequires:  python2-markupsafe
+BuildRequires:  python2-setuptools
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-babel >= 0.8
+BuildRequires:  python3-markupsafe
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-sphinx
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       python2-babel >= 0.8
+Requires:       python2-markupsafe
+%description -n python2-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3-babel >= 0.8
+Requires:       python3-markupsafe
+%description -n python3-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%py3_build
+# generate html docs
+PYTHONPATH=${PWD} sphinx-build-3 docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the default python version install last because
+# the scripts in /usr/bin are overwritten with every setup.py install.
+%py2_install
+%py3_install
+
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
+%files -n python2-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
+
+%files -n python3-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html
+%license docs/_themes/LICENSE LICENSE
+
+%changelog
+* Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-Jinja2_nc.spec
+++ b/tests/test_data/pypi_source/python-Jinja2_nc.spec
@@ -1,0 +1,107 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python2-devel
+BuildRequires:  python2-Babel >= 0.8
+BuildRequires:  python2-MarkupSafe
+BuildRequires:  python2-setuptools
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-Babel >= 0.8
+BuildRequires:  python3-MarkupSafe
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-sphinx
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       python2-Babel >= 0.8
+Requires:       python2-MarkupSafe
+%description -n python2-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3-Babel >= 0.8
+Requires:       python3-MarkupSafe
+%description -n python3-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%py3_build
+# generate html docs
+PYTHONPATH=${PWD} sphinx-build-3 docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the default python version install last because
+# the scripts in /usr/bin are overwritten with every setup.py install.
+%py2_install
+%py3_install
+
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
+%files -n python2-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
+
+%files -n python3-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html
+%license docs/_themes/LICENSE LICENSE
+
+%changelog
+* Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-Jinja2_py23_autonc.spec
+++ b/tests/test_data/pypi_source/python-Jinja2_py23_autonc.spec
@@ -1,0 +1,107 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python2-devel
+BuildRequires:  python2dist(babel) >= 0.8
+BuildRequires:  python2dist(markupsafe)
+BuildRequires:  python2dist(setuptools)
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(babel) >= 0.8
+BuildRequires:  python3dist(markupsafe)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(sphinx)
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       python2dist(babel) >= 0.8
+Requires:       python2dist(markupsafe)
+%description -n python2-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3dist(babel) >= 0.8
+Requires:       python3dist(markupsafe)
+%description -n python3-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%py3_build
+# generate html docs
+PYTHONPATH=${PWD} sphinx-build-3 docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the default python version install last because
+# the scripts in /usr/bin are overwritten with every setup.py install.
+%py2_install
+%py3_install
+
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
+%files -n python2-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
+
+%files -n python3-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html
+%license docs/_themes/LICENSE LICENSE
+
+%changelog
+* Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-Jinja2_py2_autonc.spec
+++ b/tests/test_data/pypi_source/python-Jinja2_py2_autonc.spec
@@ -1,0 +1,77 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python2-devel
+BuildRequires:  python2dist(babel) >= 0.8
+BuildRequires:  python2dist(markupsafe)
+BuildRequires:  python2dist(setuptools)
+BuildRequires:  python2dist(sphinx)
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       python2dist(babel) >= 0.8
+Requires:       python2dist(markupsafe)
+%description -n python2-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+# generate html docs
+PYTHONPATH=${PWD} sphinx-build-2 docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+%py2_install
+
+%check
+%{__python2} setup.py test
+
+%files -n python2-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python2_sitelib}/jinja2
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html
+%license docs/_themes/LICENSE LICENSE
+
+%changelog
+* Tue Mar 20 2018 Iryna Shcherbina <ishcherb@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-Jinja2_py3_autonc.spec
+++ b/tests/test_data/pypi_source/python-Jinja2_py3_autonc.spec
@@ -1,0 +1,77 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name Jinja2
+
+Name:           python-%{pypi_name}
+Version:        2.8
+Release:        1%{?dist}
+Summary:        A small but fast and easy to use stand-alone template engine written in pure python
+
+License:        BSD
+URL:            http://jinja.pocoo.org/
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(babel) >= 0.8
+BuildRequires:  python3dist(markupsafe)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(sphinx)
+
+%description
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3dist(babel) >= 0.8
+Requires:       python3dist(markupsafe)
+%description -n python3-%{pypi_name}
+Jinja2 is a template engine written in pure Python. It provides a Django_
+inspired non-XML syntax but supports inline expressions and an optional
+sandboxed_ environment.Nutshell Here a small example of a Jinja template:: {%
+extends 'base.html' %} {% block title %}Memberlist{% endblock %} {% block
+content %} <ul> {% for user in users %} <li><a href"{{ user.url }}">{{
+user.username }}</a></li>...
+
+%package -n python-%{pypi_name}-doc
+Summary:        Jinja2 documentation
+%description -n python-%{pypi_name}-doc
+Documentation for Jinja2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py3_build
+# generate html docs
+PYTHONPATH=${PWD} sphinx-build-3 docs html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+%py3_install
+
+%check
+%{__python3} setup.py test
+
+%files -n python3-%{pypi_name}
+%license docs/_themes/LICENSE LICENSE
+%doc README.rst
+%{python3_sitelib}/jinja2
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+
+%files -n python-%{pypi_name}-doc
+%doc html
+%license docs/_themes/LICENSE LICENSE
+
+%changelog
+* Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 2.8-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-StructArray_autonc.spec
+++ b/tests/test_data/pypi_source/python-StructArray_autonc.spec
@@ -1,0 +1,57 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name StructArray
+
+Name:           python-%{pypi_name}
+Version:        0.1
+Release:        1%{?dist}
+Summary:        Fast operations on arrays of structured data
+
+License:        MIT
+URL:            http://matthewmarshall.org/projects/structarray/
+Source0:        %{pypi_source}
+
+BuildRequires:  python2-devel
+BuildRequires:  python2dist(setuptools)
+
+%description
+ StructArray StructArray allows you to perform fast arithmetic operations on
+arrays of structured (or unstructured) data.This library is useful for
+performing the same operation on every item in an I've included an example
+showing a simple particle engine. It animates 10,000 particles without much
+trouble.*This is the "release early" part of the "release early, release often"
+equation. It's...
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+%description -n python2-%{pypi_name}
+ StructArray StructArray allows you to perform fast arithmetic operations on
+arrays of structured (or unstructured) data.This library is useful for
+performing the same operation on every item in an I've included an example
+showing a simple particle engine. It animates 10,000 particles without much
+trouble.*This is the "release early" part of the "release early, release often"
+equation. It's...
+
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+%check
+%{__python2} setup.py test
+
+%files -n python2-%{pypi_name}
+%{python2_sitearch}/%{pypi_name}
+%{python2_sitearch}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
+
+%changelog
+* Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 0.1-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-buildkit_autonc.spec
+++ b/tests/test_data/pypi_source/python-buildkit_autonc.spec
@@ -1,0 +1,58 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name buildkit
+
+Name:           python-%{pypi_name}
+Version:        0.2.2
+Release:        1%{?dist}
+Summary:        Cloud infrastructure and .deb file management software
+
+License:        GNU AGPLv3
+URL:            http://packages.python.org/buildkit
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python2-devel
+BuildRequires:  python2dist(setuptools)
+
+%description
+++++++++.. contents :: Summary Cloud infrastructure and .deb file management
+software.Get Started * See the docsAuthor James Gardner <>_Changes--2011-12-10
+* Changed apt-cacher-ng to run on port 3142 to avoid a potential conflict with
+supervisor2011-12-08 * Separated key generation from install of buildkit-apt-
+repo. * Made repo and key base directory settings options of the buildkit
+repo...
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       python2dist(sphinx) = 0.6.7
+%description -n python2-%{pypi_name}
+++++++++.. contents :: Summary Cloud infrastructure and .deb file management
+software.Get Started * See the docsAuthor James Gardner <>_Changes--2011-12-10
+* Changed apt-cacher-ng to run on port 3142 to avoid a potential conflict with
+supervisor2011-12-08 * Separated key generation from install of buildkit-apt-
+repo. * Made repo and key base directory settings options of the buildkit
+repo...
+
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+%files -n python2-%{pypi_name}
+%license LICENSE.txt
+%doc example/README.txt README.txt
+%{python2_sitelib}/%{pypi_name}
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
+
+%changelog
+* Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 0.2.2-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-paperwork-backend.spec
+++ b/tests/test_data/pypi_source/python-paperwork-backend.spec
@@ -1,0 +1,62 @@
+# Created by pyp2rpm-3.3.2
+%global pypi_name paperwork-backend
+
+Name:           python-%{pypi_name}
+Version:        1.2.4
+Release:        1%{?dist}
+Summary:        Paperwork's backend
+
+License:        GPLv3+
+URL:            https://github.com/openpaperwork/paperwork-backend
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(setuptools)
+
+%description
+Paperwork is a GUI to make papers searchable.This is the backend part of
+Paperwork. It manages: - The work directory / Access to the documents -
+Indexing - Searching - Suggestions- ExportThere is no GUI here. The GUI is .
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3dist(natsort)
+Requires:       python3dist(pillow)
+Requires:       python3dist(pycountry)
+Requires:       python3dist(pyenchant)
+Requires:       python3dist(pyocr)
+Requires:       python3dist(python-levenshtein)
+Requires:       python3dist(setuptools)
+Requires:       python3dist(simplebayes)
+Requires:       python3dist(termcolor)
+Requires:       python3dist(whoosh)
+%description -n python3-%{pypi_name}
+Paperwork is a GUI to make papers searchable.This is the backend part of
+Paperwork. It manages: - The work directory / Access to the documents -
+Indexing - Searching - Suggestions- ExportThere is no GUI here. The GUI is .
+
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+%files -n python3-%{pypi_name}
+%license LICENSE
+%doc README.markdown
+%{_bindir}/paperwork-shell
+%{python3_sitelib}/paperwork_backend
+%{python3_sitelib}/paperwork_backend-%{version}-py%{python3_version}.egg-info
+
+%changelog
+* Thu Mar 21 2019 Miro Hrončok <mhroncok@redhat.com> - 1.2.4-1
+- Initial package.

--- a/tests/test_data/pypi_source/python-sphinx_autonc.spec
+++ b/tests/test_data/pypi_source/python-sphinx_autonc.spec
@@ -1,0 +1,179 @@
+# Created by pyp2rpm-3.2.3
+%global pypi_name Sphinx
+%global srcname sphinx
+
+Name:           python-%{srcname}
+Version:        1.5
+Release:        1%{?dist}
+Summary:        Python documentation generator
+
+License:        BSD
+URL:            http://sphinx-doc.org/
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python2-devel
+BuildConflicts: python2dist(babel) = 2.0
+BuildRequires:  python2dist(alabaster) < 0.8
+BuildRequires:  python2dist(alabaster) >= 0.7
+BuildRequires:  python2dist(babel) >= 1.3
+BuildRequires:  python2dist(colorama) >= 0.3.5
+BuildRequires:  python2dist(docutils) >= 0.11
+BuildRequires:  python2dist(html5lib)
+BuildRequires:  python2dist(imagesize)
+BuildRequires:  python2dist(jinja2) >= 2.3
+BuildRequires:  python2dist(mock)
+BuildRequires:  python2dist(nose)
+BuildRequires:  python2dist(pygments) >= 2.0
+BuildRequires:  python2dist(requests)
+BuildRequires:  python2dist(setuptools)
+BuildRequires:  python2dist(simplejson)
+BuildRequires:  python2dist(six) >= 1.5
+BuildRequires:  python2dist(snowballstemmer) >= 1.1
+BuildRequires:  python2dist(sqlalchemy) >= 0.9
+BuildRequires:  python2dist(whoosh) >= 2.0
+
+BuildRequires:  python3-devel
+BuildConflicts: python3dist(babel) = 2.0
+BuildRequires:  python3dist(alabaster) < 0.8
+BuildRequires:  python3dist(alabaster) >= 0.7
+BuildRequires:  python3dist(babel) >= 1.3
+BuildRequires:  python3dist(colorama) >= 0.3.5
+BuildRequires:  python3dist(docutils) >= 0.11
+BuildRequires:  python3dist(html5lib)
+BuildRequires:  python3dist(imagesize)
+BuildRequires:  python3dist(jinja2) >= 2.3
+BuildRequires:  python3dist(mock)
+BuildRequires:  python3dist(nose)
+BuildRequires:  python3dist(pygments) >= 2.0
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(simplejson)
+BuildRequires:  python3dist(six) >= 1.5
+BuildRequires:  python3dist(snowballstemmer) >= 1.1
+BuildRequires:  python3dist(sqlalchemy) >= 0.9
+BuildRequires:  python3dist(whoosh) >= 2.0
+BuildRequires:  python3dist(sphinx)
+
+%description
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl. It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+Sphinx uses...
+
+%package -n     python2-%{srcname}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{srcname}}
+
+Conflicts:      python2dist(babel) = 2.0
+Requires:       python2dist(alabaster) < 0.8
+Requires:       python2dist(alabaster) >= 0.7
+Requires:       python2dist(babel) >= 1.3
+Requires:       python2dist(colorama) >= 0.3.5
+Requires:       python2dist(docutils) >= 0.11
+Requires:       python2dist(html5lib)
+Requires:       python2dist(imagesize)
+Requires:       python2dist(jinja2) >= 2.3
+Requires:       python2dist(mock)
+Requires:       python2dist(nose)
+Requires:       python2dist(pygments) >= 2.0
+Requires:       python2dist(requests)
+Requires:       python2dist(setuptools)
+Requires:       python2dist(simplejson)
+Requires:       python2dist(six) >= 1.5
+Requires:       python2dist(snowballstemmer) >= 1.1
+Requires:       python2dist(sqlalchemy) >= 0.9
+Requires:       python2dist(whoosh) >= 2.0
+%description -n python2-%{srcname}
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl. It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+Sphinx uses...
+
+%package -n     python3-%{srcname}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{srcname}}
+
+Conflicts:      python3dist(babel) = 2.0
+Requires:       python3dist(alabaster) < 0.8
+Requires:       python3dist(alabaster) >= 0.7
+Requires:       python3dist(babel) >= 1.3
+Requires:       python3dist(colorama) >= 0.3.5
+Requires:       python3dist(docutils) >= 0.11
+Requires:       python3dist(html5lib)
+Requires:       python3dist(imagesize)
+Requires:       python3dist(jinja2) >= 2.3
+Requires:       python3dist(mock)
+Requires:       python3dist(nose)
+Requires:       python3dist(pygments) >= 2.0
+Requires:       python3dist(requests)
+Requires:       python3dist(setuptools)
+Requires:       python3dist(simplejson)
+Requires:       python3dist(six) >= 1.5
+Requires:       python3dist(snowballstemmer) >= 1.1
+Requires:       python3dist(sqlalchemy) >= 0.9
+Requires:       python3dist(whoosh) >= 2.0
+%description -n python3-%{srcname}
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl. It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+Sphinx uses...
+
+%package -n python-%{srcname}-doc
+Summary:        Sphinx documentation
+%description -n python-%{srcname}-doc
+Documentation for Sphinx
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%py2_build
+%py3_build
+# generate html docs
+PYTHONPATH=${PWD} sphinx-build-3 doc html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+# Must do the default python version install last because
+# the scripts in /usr/bin are overwritten with every setup.py install.
+%py2_install
+rm -rf %{buildroot}%{_bindir}/*
+%py3_install
+
+%check
+%{__python2} setup.py test
+%{__python3} setup.py test
+
+%files -n python2-%{srcname}
+%license LICENSE
+%doc README.rst
+%{python2_sitelib}/sphinx
+%{python2_sitelib}/%{pypi_name}-%{version}-py%{python2_version}.egg-info
+
+%files -n python3-%{srcname}
+%license LICENSE
+%doc README.rst
+%{_bindir}/sphinx-apidoc
+%{_bindir}/sphinx-autogen
+%{_bindir}/sphinx-build
+%{_bindir}/sphinx-quickstart
+%{python3_sitelib}/sphinx
+%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+
+%files -n python-%{srcname}-doc
+%doc html
+%license LICENSE
+
+%changelog
+* Wed Dec 06 2017 Michal Cyprian <mcyprian@redhat.com> - 1.5-1
+- Initial package.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,10 @@ try:
     import dnf
 except ImportError:
     dnf = None
+try:
+    import rpm
+except ImportError:
+    rpm = None
 
 from pyp2rpm.bin import Convertor, SclConvertor, main, convert_to_scl
 
@@ -49,6 +53,9 @@ class TestSpec(object):
         else:
             nc = '_dnfnc' if dnf is not None else '_nc'
             variant = expected.format(nc)
+        if (rpm and rpm.expandMacro('%{pypi_source}') != '%{pypi_source}' and
+            os.path.isfile(self.td_dir + 'pypi_source/' + variant)):
+            variant = 'pypi_source/' + variant
         with open(self.td_dir + variant) as fi:
             self.spec_content = fi.read()
         res = self.env.run('{0} {1} {2}'.format(self.exe, package, options),


### PR DESCRIPTION
This implementation will only insert the pypi_source macro if it expands to the package source URL.  That means that it will only work if the "rpm" module is available, and the pypi_source macro is available (via the python-srpm-macros package on Fedora).

For testing, we'll need to add that package to the docker image, and provide alternate output files for tests where rpm is available and where pypi_source expands to a different string.