### PR TITLE
Always use the "distro" attribute for behavior checks.

### DIFF
--- a/pyp2rpm/bin.py
+++ b/pyp2rpm/bin.py
@@ -184,7 +184,7 @@ def main(package, v, d, s, r, proxy, srpm, p, b, o, t, venv, autonc, sclize,
     distro = o
     if t and os.path.splitext(t)[0] in settings.KNOWN_DISTROS:
         distro = t
-    elif t and not (b or p):
+    if not distro and not (b or p):
         raise click.UsageError("Default python versions for template {0} are "
                                "missing in settings, add them or use flags "
                                "-b/-p to set python versions.".format(t))

--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -69,14 +69,12 @@ class Convertor(object):
     @property
     def template_base_py_ver(self):
         """Return default base python version for chosen template. """
-        return settings.DEFAULT_PYTHON_VERSIONS[os.path.splitext(
-            self.template)[0]][0]
+        return settings.DEFAULT_PYTHON_VERSIONS[self.distro][0]
 
     @property
     def template_py_vers(self):
         """Return default python versions for chosen template. """
-        return settings.DEFAULT_PYTHON_VERSIONS[os.path.splitext(
-            self.template)[0]][1:]
+        return settings.DEFAULT_PYTHON_VERSIONS[self.distro][1:]
 
     def merge_versions(self, data):
         """Merges python versions specified in command lines options with
@@ -85,7 +83,7 @@ class Convertor(object):
         python_versions contain values specified by command line options or
         default values, data.python_versions contains extracted data.
         """
-        if self.template == "epel6.spec":
+        if self.distro == "epel6":
             # if user requested version greater than 2, writes error message
             # and exits
             requested_versions = self.python_versions
@@ -217,11 +215,10 @@ class Convertor(object):
     @property
     def name_convertor(self):
         if not hasattr(self, '_name_convertor'):
-            name_convertor.NameConvertor.template = os.path.splitext(
-                self.template)[0]
+            name_convertor.NameConvertor.distro = self.distro
             if self.autonc or (self.autonc is None and
-                (self.template == 'fedora.spec' or
-                 self.template == 'mageia.spec')):
+                (self.distro == 'fedora' or
+                 self.distro == 'mageia')):
                 logger.debug("Using AutoProvidesNameConvertor to convert "
                              "names of the packages.")
                 self._name_convertor = name_convertor.AutoProvidesNameConvertor(

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -11,7 +11,7 @@ def script_name_for_python_version(name, version, minor=False,
                                    default_number=True):
     if not default_number:
         if version == settings.DEFAULT_PYTHON_VERSIONS[
-                name_convertor.NameConvertor.template][0]:
+                name_convertor.NameConvertor.distro][0]:
             return name
     if minor:
         if len(version) > 1:

--- a/pyp2rpm/name_convertor.py
+++ b/pyp2rpm/name_convertor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class NameConvertor(object):
-    template = settings.DEFAULT_TEMPLATE
+    distro = settings.DEFAULT_TEMPLATE
 
     def __init__(self, distro):
         self.distro = distro
@@ -23,11 +23,11 @@ class NameConvertor(object):
     @classmethod
     def get_default_py_version(cls):
         try:
-            return settings.DEFAULT_PYTHON_VERSIONS[cls.template][0]
+            return settings.DEFAULT_PYTHON_VERSIONS[cls.distro][0]
         except KeyError:
             logger.error('Default python versions for template {0} are '
                          'missing in settings, using versions of template '
-                         '{1}.'.format(cls.template,
+                         '{1}.'.format(cls.distro,
                                        settings.DEFAULT_TEMPLATE))
             return settings.DEFAULT_PYTHON_VERSIONS[
                 settings.DEFAULT_TEMPLATE][0]
@@ -57,7 +57,7 @@ class NameConvertor(object):
             # second check is to avoid renaming of python2-devel to
             # python-devel
             if found and found.group(2) != 'devel':
-                if 'epel' not in cls.template:
+                if 'epel' not in cls.distro:
                     return 'python-{0}'.format(regexp.search(name).group(2))
             return name
 
@@ -74,7 +74,7 @@ class NameConvertor(object):
 
             else:
                 versioned_name = 'python{0}-{1}'.format(version, name)
-            if ('epel' in cls.template and version !=
+            if ('epel' in cls.distro and version !=
                     cls.get_default_py_version()):
                 versioned_name = versioned_name.replace('{0}'.format(
                     version), '%{{python{0}_pkgversion}}'.format(version))

--- a/tests/test_convertor.py
+++ b/tests/test_convertor.py
@@ -78,7 +78,8 @@ class TestConvertor(object):
     def test_merge_versions_epel6(self, self_bv, self_pv, data_bv, data_pv,
                                   expected_bv, expected_pv):
         c = Convertor(package='pkg', base_python_version=self_bv,
-                      python_versions=self_pv, template='epel6.spec')
+                      python_versions=self_pv, template='epel6.spec',
+                      distro='epel6')
         data = PackageData('pkg.tar.gz', 'pkg', 'pkg', '0.1')
         data.base_python_version = data_bv
         data.python_versions = data_pv
@@ -93,7 +94,8 @@ class TestConvertor(object):
     ])
     def test_bad_versions(self, self_bv, self_pv):
         c = Convertor(package='pkg', base_python_version=self_bv,
-                      python_versions=self_pv, template='epel6.spec')
+                      python_versions=self_pv, template='epel6.spec',
+                      distro='epel6')
         data = PackageData('pkg.tar.gz', 'pkg', 'pkg', '0.1')
         with pytest.raises(SystemExit):
             c.merge_versions(data)


### PR DESCRIPTION
This allows users to specify a template file without requiring that its name be "distro" + ".spec".