### PR TITLE
Use pypi_source macro

### DIFF
--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -62,10 +62,19 @@ def package_to_path(package, module):
         return package
 
 
+def macroed_url(url):
+    if (url.startswith('https://files.pythonhosted.org/packages/source/') and
+        (url.endswith('/%{pypi_name}/%{pypi_name}-%{version}.tar.gz') or
+         url.endswith('/%{pypi_name}/%{pypi_name}-%{version}.zip'))):
+        return '%{pypi_source}'
+    return url
+
+
 __all__ = [name_for_python_version,
            script_name_for_python_version,
            sitedir_for_python_version,
            python_bin_for_python_version,
            macroed_pkg_name,
            module_to_path,
-           package_to_path]
+           package_to_path,
+           macroed_url]

--- a/pyp2rpm/filters.py
+++ b/pyp2rpm/filters.py
@@ -63,10 +63,11 @@ def package_to_path(package, module):
 
 
 def macroed_url(url):
-    if (url.startswith('https://files.pythonhosted.org/packages/source/') and
-        (url.endswith('/%{pypi_name}/%{pypi_name}-%{version}.tar.gz') or
-         url.endswith('/%{pypi_name}/%{pypi_name}-%{version}.zip'))):
-        return '%{pypi_source}'
+    if url.startswith('https://files.pythonhosted.org/packages/source/'):
+        if url.endswith('/%{pypi_name}/%{pypi_name}-%{version}.tar.gz'):
+            return '%{pypi_source}'
+        elif url.endswith('/%{pypi_name}/%{pypi_name}-%{version}.zip'):
+            return '%{pypi_source %{pypi_name} %{version} zip}'
     return url
 
 

--- a/pyp2rpm/templates/fedora.spec
+++ b/pyp2rpm/templates/fedora.spec
@@ -1,5 +1,5 @@
 {{ data.credit_line }}
-{% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi -%}
+{% from 'macros.spec' import dependencies, for_python_versions, underscored_or_pypi, macroed_url -%}
 %global pypi_name {{ data.name }}
 {%- if data.srcname %}
 %global srcname {{ data.srcname }}
@@ -12,7 +12,7 @@ Summary:        {{ data.summary }}
 
 License:        {{ data.license }}
 URL:            {{ data.home_page }}
-Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}') }}
+Source0:        {{ data.source0|replace(data.name, '%{pypi_name}')|replace(data.version, '%{version}')|macroed_url }}
 
 {%- if not data.has_extension %}
 BuildArch:      noarch
@@ -50,7 +50,7 @@ rm -rf %{pypi_name}.egg-info
 %py{{ pv }}_build
 {%- endfor %}
 {%- if data.sphinx_dir %}
-# generate html docs 
+# generate html docs
 PYTHONPATH=${PWD} {{ "sphinx-build"|script_name_for_python_version(data.base_python_version, False, True) }} {{ data.sphinx_dir }} html
 # remove the sphinx-build leftovers
 rm -rf html/.{doctrees,buildinfo}

--- a/tests/test_data/python-Jinja2_dnfnc.spec
+++ b/tests/test_data/python-Jinja2_dnfnc.spec
@@ -8,7 +8,7 @@ Summary:        A small but fast and easy to use stand-alone template engine wri
 
 License:        BSD
 URL:            http://jinja.pocoo.org/
-Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python2-devel

--- a/tests/test_data/python-Jinja2_nc.spec
+++ b/tests/test_data/python-Jinja2_nc.spec
@@ -8,7 +8,7 @@ Summary:        A small but fast and easy to use stand-alone template engine wri
 
 License:        BSD
 URL:            http://jinja.pocoo.org/
-Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python2-devel

--- a/tests/test_data/python-Jinja2_py23_autonc.spec
+++ b/tests/test_data/python-Jinja2_py23_autonc.spec
@@ -8,7 +8,7 @@ Summary:        A small but fast and easy to use stand-alone template engine wri
 
 License:        BSD
 URL:            http://jinja.pocoo.org/
-Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python2-devel

--- a/tests/test_data/python-Jinja2_py2_autonc.spec
+++ b/tests/test_data/python-Jinja2_py2_autonc.spec
@@ -8,7 +8,7 @@ Summary:        A small but fast and easy to use stand-alone template engine wri
 
 License:        BSD
 URL:            http://jinja.pocoo.org/
-Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python2-devel

--- a/tests/test_data/python-Jinja2_py3_autonc.spec
+++ b/tests/test_data/python-Jinja2_py3_autonc.spec
@@ -8,7 +8,7 @@ Summary:        A small but fast and easy to use stand-alone template engine wri
 
 License:        BSD
 URL:            http://jinja.pocoo.org/
-Source0:        https://files.pythonhosted.org/packages/source/J/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python3-devel

--- a/tests/test_data/python-StructArray_autonc.spec
+++ b/tests/test_data/python-StructArray_autonc.spec
@@ -8,7 +8,7 @@ Summary:        Fast operations on arrays of structured data
 
 License:        MIT
 URL:            http://matthewmarshall.org/projects/structarray/
-Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 
 BuildRequires:  python2-devel
 BuildRequires:  python2dist(setuptools)

--- a/tests/test_data/python-buildkit_autonc.spec
+++ b/tests/test_data/python-buildkit_autonc.spec
@@ -8,7 +8,7 @@ Summary:        Cloud infrastructure and .deb file management software
 
 License:        GNU AGPLv3
 URL:            http://packages.python.org/buildkit
-Source0:        https://files.pythonhosted.org/packages/source/b/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python2-devel

--- a/tests/test_data/python-paperwork-backend.spec
+++ b/tests/test_data/python-paperwork-backend.spec
@@ -8,7 +8,7 @@ Summary:        Paperwork's backend
 
 License:        GPLv3+
 URL:            https://github.com/openpaperwork/paperwork-backend
-Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python3-devel

--- a/tests/test_data/python-sphinx_autonc.spec
+++ b/tests/test_data/python-sphinx_autonc.spec
@@ -9,7 +9,7 @@ Summary:        Python documentation generator
 
 License:        BSD
 URL:            http://sphinx-doc.org/
-Source0:        https://files.pythonhosted.org/packages/source/S/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        %{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python2-devel


### PR DESCRIPTION
PR #198 might be ... over-engineered.  This change will also support the pypi_source macro, but with fewer external requirements.  As a result, it's also a much smaller patch.