### PR TITLE
Remove "version" arg from VirtualEnv class init.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ MANIFEST
 .eggs/
 tests/test_output/
 tests/test_data/utest-*.tar.gz
+tests/test_data/*/*.egg-info

--- a/pyp2rpm/metadata_extractors.py
+++ b/pyp2rpm/metadata_extractors.py
@@ -134,7 +134,7 @@ def venv_metadata_extension(extraction_fce):
 
         temp_dir = tempfile.mkdtemp()
         try:
-            extractor = virtualenv.VirtualEnv(self.local_file, self.version,
+            extractor = virtualenv.VirtualEnv(self.local_file,
                                               temp_dir,
                                               self.name_convertor,
                                               self.base_python_version)

--- a/pyp2rpm/virtualenv.py
+++ b/pyp2rpm/virtualenv.py
@@ -59,10 +59,9 @@ class DirsContent(object):
 
 class VirtualEnv(object):
 
-    def __init__(self, name, version, temp_dir, name_convertor,
+    def __init__(self, name, temp_dir, name_convertor,
                  base_python_version):
         self.name = name
-        self.version = version
         self.temp_dir = temp_dir
         self.name_convertor = name_convertor
         if not base_python_version:
@@ -86,7 +85,7 @@ class VirtualEnv(object):
         dependencies
         '''
         try:
-            self.env.install((self.name, self.version), force=True,
+            self.env.install((self.name,), force=True,
                              options=["--no-deps"])
         except (ve.PackageInstallationException,
                 ve.VirtualenvReadonlyException):

--- a/tests/test_data/python-utest.spec
+++ b/tests/test_data/python-utest.spec
@@ -27,7 +27,9 @@ Requires:       (python3dist(pyp2rpm) >= 3.3.1 with python3dist(pyp2rpm) < 3.4)
 
 
 %prep
-%autosetup -n tests/test_data/%{pypi_name}
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
 
 %build
 %py3_build

--- a/tests/test_data/python-utest_epel7.spec
+++ b/tests/test_data/python-utest_epel7.spec
@@ -27,7 +27,9 @@ Requires:       python%{python3_pkgversion}-pyp2rpm >= 3.3.1
 
 
 %prep
-%autosetup -n tests/test_data/%{pypi_name}
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
 
 %build
 %{__python3} setup.py build

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import shutil
 import tempfile
@@ -15,6 +16,7 @@ from pyp2rpm.settings import DEFAULT_DISTRO, DEFAULT_PYTHON_VERSION
 pytestmark = pytest.mark.skipif(VirtualEnv is None,
                                 reason="virtualenv-api not installed")
 
+tests_dir = os.path.split(os.path.abspath(__file__))[0]
 
 class TestUtils(object):
 
@@ -65,11 +67,31 @@ class TestDirsContent(object):
         assert result.lib_sitepackages == expected
 
 
+class TestVirtualEnvGetData(object):
+
+    def setup_method(self, method):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
+
+    @pytest.mark.parametrize(('file', 'expected'), [
+        ('{}/test_data/utest-0.1.0.tar.gz'.format(tests_dir),
+         {'py_modules': [], 'scripts': [], 'packages': ['utest'], 'has_pth': False}),
+    ])
+    def test_get_data(self, file, expected):
+        self.venv = VirtualEnv(name=file,
+                               temp_dir=self.temp_dir,
+                               name_convertor=NameConvertor(DEFAULT_DISTRO),
+                               base_python_version=DEFAULT_PYTHON_VERSION)
+        assert(self.venv.get_venv_data == expected)
+
+
 class TestVirtualEnv(object):
 
     def setup_method(self, method):
         self.temp_dir = tempfile.mkdtemp()
-        self.venv = VirtualEnv(name=None, version=None,
+        self.venv = VirtualEnv(name=None,
                                temp_dir=self.temp_dir,
                                name_convertor=NameConvertor(DEFAULT_DISTRO),
                                base_python_version=DEFAULT_PYTHON_VERSION)

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ deps =
     scripttest
     click
     spec2scl >= 1.2.0
-whitelist_externals = tar
+whitelist_externals = sh
 commands =
-    tar zcf tests/test_data/utest-0.1.0.tar.gz tests/test_data/utest
+    sh -c 'cd tests/test_data/utest && python3 setup.py sdist && mv dist/utest-0.1.0.tar.gz ..'
     python setup.py test --addopts -vv
 sitepackages = True


### PR DESCRIPTION
Remove "version" arg from VirtualEnv class init.  Because "name"
is a local file, "version" is not necessary.