### PR TITLE
Add RHEL 8 and RHEL 9, discard RHEL 6 special options

### DIFF
--- a/pyp2rpm/convertor.py
+++ b/pyp2rpm/convertor.py
@@ -81,25 +81,10 @@ class Convertor(object):
 
     def merge_versions(self, data):
         """Merges python versions specified in command lines options with
-        extracted versions, checks if some of the versions is not > 2 if EPEL6
-        template will be used. attributes base_python_version and
+        extracted versions. Attributes base_python_version and
         python_versions contain values specified by command line options or
         default values, data.python_versions contains extracted data.
         """
-        if self.distro == "epel6":
-            # if user requested version greater than 2, writes error message
-            # and exits
-            requested_versions = self.python_versions
-            if self.base_python_version:
-                requested_versions += [self.base_python_version]
-            if any(int(ver[0]) > 2 for ver in requested_versions):
-                sys.stderr.write(
-                    "Invalid version, major number of python version for "
-                    "EPEL6 spec file must not be greater than 2.\n")
-                sys.exit(1)
-            # if version greater than 2 were extracted it is removed
-            data.python_versions = [
-                ver for ver in data.python_versions if not int(ver[0]) > 2]
 
         # Set python versions from default values in settings.
         base_version, additional_versions = (

--- a/pyp2rpm/settings.py
+++ b/pyp2rpm/settings.py
@@ -3,10 +3,12 @@ from pyp2rpm import utils
 DEFAULT_TEMPLATE = 'fedora'
 DEFAULT_PYTHON_VERSIONS = {
     'fedora': ['3'],
-    'epel7': ['2', '3'],
-    'epel6': ['2'],
+    'epel9': ['3'],
+    'epel8': ['3'],
+    'epel7': ['3'],
+    'epel6': ['3'],
     'mageia': ['3'],
-    'pld': ['2', '3']
+    'pld': ['3']
 }
 DEFAULT_PYTHON_VERSION = DEFAULT_PYTHON_VERSIONS[DEFAULT_TEMPLATE][0]
 DEFAULT_PKG_SOURCE = 'pypi'


### PR DESCRIPTION
Stop publishing python2 builds for RHEL 6 and 7. Add python3 builds for RHEL 8 and RHEL 9.

RHEL 6 is deprecated, and before its discard had support for python3 form EPEL before its obsolescence.