### PR TITLE
Replace pytest-runner with pytest for testing pyp2rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
                       ],
     setup_requires=['setuptools',
                     'flexmock >= 0.9.3',
-                    'pytest-runner',
                     'click',
                     'Jinja2',
                     ],

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py36, py37, py38, py39, py310
 
 [testenv]
 deps =
+    pytest
     pyparsing
     more-itertools <= 7.2.0
     setuptools
@@ -17,5 +18,5 @@ allowlist_externals = sh
 commands =
     sh -c 'cd tests/test_data/utest && python3 setup.py sdist && mv dist/utest-0.1.0.tar.gz ..'
     sh -c 'cd tests/test_data/isholiday-0.1 && python3 setup.py sdist && mv dist/isholiday-0.1.tar.gz ..'
-    python setup.py test --addopts -vv
+    python -m pytest -vv
 sitepackages = True


### PR DESCRIPTION
This does not change the spec files generated by `pyp2rpm`, but it gets `tox` working again with current `setuptools` releases.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Additionally, the long-deprecated "setup.py test" command was removed in setuptools 72:
https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

See also https://fedoraproject.org/wiki/Changes/DeprecatePythonPytestRunner.